### PR TITLE
feat: Initial K8s Manifest

### DIFF
--- a/deployment/k8s/http-proxy.yaml
+++ b/deployment/k8s/http-proxy.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: meli
 spec:
   virtualhost:
-    fqdn: meli.domain.io
+    fqdn: meli.domain.io #ChangeMe
   routes:
    - services:
      - name: meli-svc
@@ -14,3 +14,22 @@ spec:
          set:
          - name: X-Forwarded-Proto
            value: https
+# ATM Contour does not support Wildcard FQDN - you have to add Additional config for your sites.
+# TODO: Add Nginx-Ingress Example with Wildcard
+#---           
+#apiVersion: projectcontour.io/v1
+#kind: HTTPProxy
+#metadata:
+#  name: meli-ing
+#  namespace: meli
+#spec:
+#  virtualhost:
+#    fqdn: site.meli.domain.io #ChangeMe
+#  routes:
+#   - services:
+#     - name: meli-svc
+#       port: 80
+#       requestHeadersPolicy: #Required if SSL is Offloaded
+#         set:
+#         - name: X-Forwarded-Proto
+#           value: https           

--- a/deployment/k8s/http-proxy.yaml
+++ b/deployment/k8s/http-proxy.yaml
@@ -12,5 +12,5 @@ spec:
        port: 80
        requestHeadersPolicy: #Required if SSL is Offloaded
          set:
-         - name: X-Forwarded-Proto 
+         - name: X-Forwarded-Proto
            value: https

--- a/deployment/k8s/http-proxy.yaml
+++ b/deployment/k8s/http-proxy.yaml
@@ -10,7 +10,7 @@ spec:
    - services:
      - name: meli-svc
        port: 80
-       requestHeadersPolicy:
+       requestHeadersPolicy: #Required if SSL is Offloaded
          set:
-         - name: X-Forwarded-Proto
+         - name: X-Forwarded-Proto 
            value: https

--- a/deployment/k8s/http-proxy.yaml
+++ b/deployment/k8s/http-proxy.yaml
@@ -1,0 +1,16 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: meli-ing
+  namespace: meli
+spec:
+  virtualhost:
+    fqdn: meli.domain.io
+  routes:
+   - services:
+     - name: meli-svc
+       port: 80
+       requestHeadersPolicy:
+         set:
+         - name: X-Forwarded-Proto
+           value: https

--- a/deployment/k8s/meli-deployment.yaml
+++ b/deployment/k8s/meli-deployment.yaml
@@ -78,11 +78,14 @@ spec:
             - name: sites
               mountPath: /sites
               subPath: sites              
-          #livenessProbe:
+          #livenessProbe: #Uncomment & change host header value
           #  httpGet:
           #    path: /
           #    port: admin
           #    scheme: HTTP
+          #    httpHeaders:
+          #      - name: Host
+          #        value: "meli.domain.io" #ChangeMe            
           #  initialDelaySeconds: 60
           #  timeoutSeconds: 5
           #  periodSeconds: 10
@@ -93,6 +96,9 @@ spec:
           #    path: /
           #    port: admin
           #    scheme: HTTP
+          #    httpHeaders:
+          #      - name: Host
+          #        value: "meli.domain.io" #ChangeMe 
           #  initialDelaySeconds: 30
           #  timeoutSeconds: 5
           #  periodSeconds: 10

--- a/deployment/k8s/meli-deployment.yaml
+++ b/deployment/k8s/meli-deployment.yaml
@@ -1,0 +1,353 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: meli
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: meli-app
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: meli-app
+      app.kubernetes.io/name: meli
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: meli-app
+        app.kubernetes.io/name: meli
+    spec:
+      containers:
+        - name: meli
+          image: getmeli/meli:beta
+          env:
+          - name: MELI_JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: meli
+                key: meli-jwt
+          - name: MELI_MONGO_URI
+            value: mongodb://mongouser:ChangeMe@mongo:27017/meli #ChangeMe (See: Mongo Secret)
+          - name: MELI_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: meli
+                key: meli-password
+          - name: MELI_URL
+            value: https://meli.domain.io #ChangeMe
+          - name: MELI_USER
+            value: user #ChangeMe
+          - name: MELI_HTTPS_AUTO
+            value: "false"
+          imagePullPolicy: IfNotPresent
+          ports:
+          - name: http
+            containerPort: 80
+            protocol: TCP
+          - name: https
+            containerPort: 443
+            protocol: TCP
+          - name: api
+            containerPort: 3001
+            protocol: TCP
+          - name: admin
+            containerPort: 2019
+            protocol: TCP                          
+          #securityContext:
+          #  runAsUser: 1001
+          volumes: null
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            #limits:
+            #  cpu500m
+          volumeMounts:
+            - name: data
+              mountPath: /data
+              subPath: data
+            - name: config
+              mountPath: /config
+              subPath: config
+            - name: sites
+              mountPath: /sites
+              subPath: sites              
+          #livenessProbe:
+          #  httpGet:
+          #    path: /
+          #    port: admin
+          #    scheme: HTTP
+          #  initialDelaySeconds: 60
+          #  timeoutSeconds: 5
+          #  periodSeconds: 10
+          #  successThreshold: 1
+          #  failureThreshold: 6
+          #readinessProbe:
+          #  httpGet:
+          #    path: /
+          #    port: admin
+          #    scheme: HTTP
+          #  initialDelaySeconds: 30
+          #  timeoutSeconds: 5
+          #  periodSeconds: 10
+          #  successThreshold: 1
+          #  failureThreshold: 6
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: pvc-data
+        - name: config
+          persistentVolumeClaim:
+            claimName: pvc-config
+        - name: sites
+          persistentVolumeClaim:
+            claimName: pvc-sites
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      serviceAccountName: default
+      serviceAccount: default
+      #securityContext:
+      #  fsGroup: 1001
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: meli
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli
+stringData:
+  meli-password: ChangeMe #ChangeMe
+  meli-jwt: ChangeMe #ChangeMe
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-data
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  #storageClassName: {}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-config
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  #storageClassName: {}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-sites
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  #storageClassName: {}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: meli-svc
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli 
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: https
+    - name: admin
+      protocol: TCP
+      port: 2019
+      targetPort: admin
+    - name: api
+      protocol: TCP
+      port: 3001
+      targetPort: api            
+  selector:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli 
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mongo
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-mongo
+    app.kubernetes.io/name: meli 
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: meli-mongo
+      app.kubernetes.io/name: meli 
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: meli-mongo
+        app.kubernetes.io/name: meli 
+    spec:
+      containers:
+        - image: bitnami/mongodb
+          imagePullPolicy: IfNotPresent
+          name: mongo
+          securityContext:
+            runAsUser: 1001
+            runAsNonRoot: true         
+          ports:
+          - name: mongo-port
+            containerPort: 27017
+            protocol: TCP
+          env:
+            - name: MONGODB_USERNAME
+              value: mongouser #ChangeME
+            - name: MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mongo
+                  key: mongo-password
+            - name: MONGODB_DATABASE
+              value: meli              
+            - name: MONGODB_ROOT_PASSWOR
+              valueFrom:
+                secretKeyRef:
+                  name: mongo
+                  key: mongo-root-pw
+            - name: BITNAMI_DEBUG
+              value: "false"
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            #limits:
+            #  cpu500m
+          volumeMounts:
+            - name: data-db
+              mountPath: /bitnami/mongodb
+              subPath: mongodb
+          livenessProbe:
+            exec:
+              command:
+                - mongo
+                - '--disableImplicitSessions'
+                - '--eval'
+                - db.adminCommand('ping')
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - bash
+                - '-ec'
+                - >
+                  mongo --disableImplicitSessions $TLS_OPTIONS --eval
+                  'db.hello().isWritablePrimary || db.hello().secondary' | grep
+                  -q 'true'
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 6
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File                                          
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      serviceAccountName: default
+      serviceAccount: default
+      securityContext:
+        fsGroup: 1001      
+      volumes:
+        - name: data-db
+          persistentVolumeClaim:
+            claimName: pvc-data-db          
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-data-db
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-mongo
+    app.kubernetes.io/name: meli 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  #storageClassName: {}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mongo
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-mongo
+    app.kubernetes.io/name: meli 
+spec:
+  ports:
+    - name: mongo-svc-port
+      protocol: TCP
+      port: 27017
+      targetPort: mongo-port
+  selector:
+    app.kubernetes.io/instance: meli-mongo
+    app.kubernetes.io/name: meli 
+  type: ClusterIP
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mongo
+  namespace: meli
+  labels:
+    app.kubernetes.io/instance: meli-app
+    app.kubernetes.io/name: meli
+stringData:
+  mongo-password: ChangeMe #ChangeMe
+  mongo-root-pw: ChangeMe #ChangeMe

--- a/deployment/k8s/meli-deployment.yaml
+++ b/deployment/k8s/meli-deployment.yaml
@@ -248,7 +248,7 @@ spec:
                   key: mongo-password
             - name: MONGODB_DATABASE
               value: meli              
-            - name: MONGODB_ROOT_PASSWOR
+            - name: MONGODB_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: mongo


### PR DESCRIPTION
Initial Commit of Kubernetes Manifest!
_It's working on my K8s Cluster.. :)_

**Ingress**: SSL offload works fine, MELI_URL should still start with "https"
HTTPProxy requires: [Project Contour](https://projectcontour.io/)


**Todo**: livenessProbe & readinessProbe for Meli

**Recommendation**: 

- make Dockferfile "non-root", then we could run the container as "1001".
- MELI_MONGO_URI should be built at runtime with e.g. a bash script. Then we could pass mongo password as a Secret from another ENV Var


