### PR TITLE
Update DomainForm with private key help text

### DIFF
--- a/ui/src/components/sites/settings/DomainForm.tsx
+++ b/ui/src/components/sites/settings/DomainForm.tsx
@@ -53,6 +53,7 @@ export function ManualConfig({ input, item }: { input: string; item: SiteDomain 
             defaultValue={(item.sslConfiguration as ManualSslConfiguration)?.privateKey}
             className="form-control"
           />
+          <div className="form-text">Paste your private key including the line beginning with -----BEGIN RSA PRIVATE KEY----- everything between and ending with -----END RSA PRIVATE KEY----- making sure they match those words exactly.</div>
           <InputError error={errors} path={sslPrivateKey}/>
         </div>
       </div>


### PR DESCRIPTION
A very minor change to help some RSA private key help text under the textarea. This is related to #228 and should help future users understand they need a specific string to match to be able to save the form.