### PR TITLE
feat(ui): Improve toast error messages

### DIFF
--- a/ui/src/components/auth/Orgs.tsx
+++ b/ui/src/components/auth/Orgs.tsx
@@ -1,27 +1,26 @@
-import React, { useEffect, useState } from 'react';
-import classNames from 'classnames';
-import { toast } from 'react-toastify';
-import { axios } from '../../providers/axios';
-import { Loader } from '../../commons/components/Loader';
-import { AlertError } from '../../commons/components/AlertError';
-import { Bubble } from '../../commons/components/Bubble';
-import styles from './Orgs.module.scss';
-import { useCurrentOrg } from '../../providers/OrgProvider';
-import { UserOrg } from './user-org';
-import { AddOrg } from '../orgs/AddOrg';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import classNames from "classnames";
+import { toast } from "react-toastify";
+import { axios } from "../../providers/axios";
+import { Loader } from "../../commons/components/Loader";
+import { AlertError } from "../../commons/components/AlertError";
+import { Bubble } from "../../commons/components/Bubble";
+import styles from "./Orgs.module.scss";
+import { useCurrentOrg } from "../../providers/OrgProvider";
+import { UserOrg } from "./user-org";
+import { AddOrg } from "../orgs/AddOrg";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
-function OrgItem({ item }: {
-  item: UserOrg;
-}) {
+function OrgItem({ item }: { item: UserOrg }) {
   const { changeCurrentOrg } = useCurrentOrg();
   const [loading, setLoading] = useMountedState(false);
 
   const selectOrg = () => {
     setLoading(true);
     changeCurrentOrg(item.org._id)
-      .catch(err => {
-        toast.error(`Could not select org: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not select org: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(true);
@@ -34,12 +33,10 @@ function OrgItem({ item }: {
       onClick={selectOrg}
     >
       <div className="d-flex align-items-center">
-        <Bubble color={item.org.color} src={item.org.logo} className="mr-3"/>
+        <Bubble color={item.org.color} src={item.org.logo} className="mr-3" />
         <strong>{item.org.name}</strong>
       </div>
-      {loading && (
-        <Loader/>
-      )}
+      {loading && <Loader />}
     </li>
   );
 }
@@ -69,31 +66,30 @@ export function Orgs() {
   };
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
-    <div className={classNames(styles.container, 'page')}>
+    <div className={classNames(styles.container, "page")}>
       <div className="container">
         <div className="row">
           <div className="col d-flex justify-content-center">
             <div className={styles.grid}>
-
               <h2 className={styles.title}>Organization</h2>
               <p className="text-center">Select an organization</p>
 
               <ul className="list-group">
-                {items.map(item => (
-                  <OrgItem
-                    key={item.org._id}
-                    item={item}
-                  />
+                {items.map((item) => (
+                  <OrgItem key={item.org._id} item={item} />
                 ))}
               </ul>
 
               <AddOrg
                 onAdded={onAdded}
-                className={classNames('list-group-item list-group-item-action', styles.add)}
+                className={classNames(
+                  "list-group-item list-group-item-action",
+                  styles.add
+                )}
                 tooltip={false}
               >
                 Add org

--- a/ui/src/components/auth/methods/SignInWithUserPassword.tsx
+++ b/ui/src/components/auth/methods/SignInWithUserPassword.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { maxLength, required } from '../../../commons/components/forms/form-constants';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../providers/axios';
-import { useAuth } from '../../../providers/AuthProvider';
-import { Button } from '../../../commons/components/Button';
+import React from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import {
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { InputError } from "../../../commons/components/forms/InputError";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../providers/axios";
+import { useAuth } from "../../../providers/AuthProvider";
+import { Button } from "../../../commons/components/Button";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface FormData {
   user: string;
@@ -25,8 +29,8 @@ function useSignIn() {
       .then(() => {
         fetchUser();
       })
-      .catch(err => {
-        toast.error(`Could not sign in: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not sign in: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -37,19 +41,17 @@ function useSignIn() {
   };
 }
 
-export function SignInWithUserPassword({ className }: {
-  className?;
-}) {
+export function SignInWithUserPassword({ className }: { className? }) {
   const {
-    register, errors, handleSubmit, formState: { isDirty },
+    register,
+    errors,
+    handleSubmit,
+    formState: { isDirty },
   } = useForm();
   const { loading, signIn } = useSignIn();
 
   return (
-    <form
-      onSubmit={handleSubmit(signIn)}
-      className={classNames(className)}
-    >
+    <form onSubmit={handleSubmit(signIn)} className={classNames(className)}>
       <div className="form-group">
         <label htmlFor="user">User</label>
         <input
@@ -63,7 +65,7 @@ export function SignInWithUserPassword({ className }: {
           className="form-control"
           autoComplete="off"
         />
-        <InputError error={errors} path="user"/>
+        <InputError error={errors} path="user" />
       </div>
       <div className="form-group">
         <label htmlFor="password">Password</label>
@@ -78,7 +80,7 @@ export function SignInWithUserPassword({ className }: {
           className="form-control"
           autoComplete="off"
         />
-        <InputError error={errors} path="password"/>
+        <InputError error={errors} path="password" />
       </div>
       <Button
         type="submit"

--- a/ui/src/components/commons/Logo.tsx
+++ b/ui/src/components/commons/Logo.tsx
@@ -1,21 +1,27 @@
-import React, { useState } from 'react';
-import { useDropzone } from 'react-dropzone';
-import { toast } from 'react-toastify';
-import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUpload } from '@fortawesome/free-solid-svg-icons';
-import classNames from 'classnames';
-import { ButtonIcon } from '../../commons/components/ButtonIcon';
-import { Bubble } from '../../commons/components/Bubble';
-import { axios } from '../../providers/axios';
-import styles from './Logo.module.scss';
+import React, { useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { toast } from "react-toastify";
+import { faTrashAlt } from "@fortawesome/free-regular-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUpload } from "@fortawesome/free-solid-svg-icons";
+import classNames from "classnames";
+import { ButtonIcon } from "../../commons/components/ButtonIcon";
+import { Bubble } from "../../commons/components/Bubble";
+import { axios } from "../../providers/axios";
+import styles from "./Logo.module.scss";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 interface Value {
   _id: string;
   logo?: string;
 }
 
-export function Logo<T extends Value>({ context, value, setValue, className }: {
+export function Logo<T extends Value>({
+  context,
+  value,
+  setValue,
+  className,
+}: {
   context: string;
   value: T;
   setValue: (value: T) => void;
@@ -24,22 +30,22 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
   const [uploading, setUploading] = useState(false);
   const [isDragActive, setIsDragActive] = useState(false);
 
-  const onFileDropped = acceptedFiles => {
+  const onFileDropped = (acceptedFiles) => {
     setIsDragActive(false);
     setUploading(true);
     const formData = new FormData();
-    formData.append('file', acceptedFiles[0]);
+    formData.append("file", acceptedFiles[0]);
     axios
       .post<T>(`/api/v1/${context}/${value._id}/logo`, formData, {
         headers: {
-          'Content-Type': 'multipart/form-data',
+          "Content-Type": "multipart/form-data",
         },
       })
       .then(({ data }) => {
         setValue(data);
       })
-      .catch(err => {
-        toast.error(`Could not upload logo: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not upload logo: ${extractErrorMessage(err)}`);
       })
       .finally(() => setUploading(false));
   };
@@ -53,8 +59,8 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
       .then(({ data }) => {
         setValue(data);
       })
-      .catch(err => {
-        toast.error(`Could not remove logo: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not remove logo: ${extractErrorMessage(err)}`);
       })
       .finally(() => setRemoving(false));
   };
@@ -70,7 +76,7 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
 
   return (
     <div
-      className={classNames('card', className, styles.dropzone, {
+      className={classNames("card", className, styles.dropzone, {
         [styles.active]: isDragActive,
       })}
       {...getRootProps()}
@@ -80,20 +86,18 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
       </div>
       <div className="card-body d-flex justify-content-between align-items-center">
         {value.logo ? (
-          <Bubble src={value.logo} className={styles.logo}/>
+          <Bubble src={value.logo} className={styles.logo} />
         ) : (
-          <div className="text-muted">
-            Drag a file here
-          </div>
+          <div className="text-muted">Drag a file here</div>
         )}
         <div className="d-flex align-items-center">
           <input {...getInputProps()} />
           <ButtonIcon loading={uploading} onClick={open}>
-            <FontAwesomeIcon icon={faUpload}/>
+            <FontAwesomeIcon icon={faUpload} />
           </ButtonIcon>
           {value.logo && (
             <ButtonIcon loading={removing} onClick={removeLogo}>
-              <FontAwesomeIcon icon={faTrashAlt}/>
+              <FontAwesomeIcon icon={faTrashAlt} />
             </ButtonIcon>
           )}
         </div>

--- a/ui/src/components/hooks/AddHook.tsx
+++ b/ui/src/components/hooks/AddHook.tsx
@@ -1,32 +1,36 @@
-import React, { useCallback } from 'react';
-import { toast } from 'react-toastify';
-import { useRouteMatch } from 'react-router-dom';
-import { Hook, HookType } from './hook';
-import { routerHistory } from '../../providers/history';
-import { axios } from '../../providers/axios';
-import { HookForm } from './form/HookForm';
-import { useHookContext } from './HookProvider';
-import { routeUp } from '../../commons/utils/route-up';
+import React, { useCallback } from "react";
+import { toast } from "react-toastify";
+import { useRouteMatch } from "react-router-dom";
+import { Hook, HookType } from "./hook";
+import { routerHistory } from "../../providers/history";
+import { axios } from "../../providers/axios";
+import { HookForm } from "./form/HookForm";
+import { useHookContext } from "./HookProvider";
+import { routeUp } from "../../commons/utils/route-up";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function AddHook() {
   const { context } = useHookContext();
   const { url } = useRouteMatch();
   const onChange = useCallback(
-    (data: Hook): Promise<void> => axios
-      .post<Hook>(`/api/v1/${context}/hooks`, data)
-      .then(() => {
-        routerHistory.push(routeUp(url));
-      })
-      .catch(err => {
-        toast.error(`Could not create hook: ${err}`);
-      }),
-    [context, url],
+    (data: Hook): Promise<void> =>
+      axios
+        .post<Hook>(`/api/v1/${context}/hooks`, data)
+        .then(() => {
+          routerHistory.push(routeUp(url));
+        })
+        .catch((err) => {
+          toast.error(`Could not create hook: ${extractErrorMessage(err)}`);
+        }),
+    [context, url]
   );
   return (
     <HookForm
-      value={{
-        type: HookType.web,
-      } as any}
+      value={
+        {
+          type: HookType.web,
+        } as any
+      }
       onChange={onChange}
     />
   );

--- a/ui/src/components/hooks/DeleteHook.tsx
+++ b/ui/src/components/hooks/DeleteHook.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../commons/components/Button';
-import { axios } from '../../providers/axios';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { useHookContext } from './HookProvider';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../commons/components/Button";
+import { axios } from "../../providers/axios";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { useHookContext } from "./HookProvider";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function DeleteHook({
-  hookId, className, children, onDelete,
+  hookId,
+  className,
+  children,
+  onDelete,
 }: {
   hookId: string;
   children: any;
@@ -26,8 +30,8 @@ export function DeleteHook({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete hook: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete hook: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/hooks/HookList.tsx
+++ b/ui/src/components/hooks/HookList.tsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Link, useRouteMatch } from 'react-router-dom';
-import styles from './HookList.module.scss';
-import { EmptyList } from '../../commons/components/EmptyList';
-import { axios } from '../../providers/axios';
-import { Loader } from '../../commons/components/Loader';
-import { AlertError } from '../../commons/components/AlertError';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { useHookContext } from './HookProvider';
-import { Hook } from './hook';
-import { HookIcon } from '../icons/HookIcon';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Link, useRouteMatch } from "react-router-dom";
+import styles from "./HookList.module.scss";
+import { EmptyList } from "../../commons/components/EmptyList";
+import { axios } from "../../providers/axios";
+import { Loader } from "../../commons/components/Loader";
+import { AlertError } from "../../commons/components/AlertError";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { useHookContext } from "./HookProvider";
+import { Hook } from "./hook";
+import { HookIcon } from "../icons/HookIcon";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 function sortHooks(a: Hook, b: Hook): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -27,19 +28,19 @@ export function HookList() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get<Hook[]>(`/api/v1/${context}/hooks`)
+    axios
+      .get<Hook[]>(`/api/v1/${context}/hooks`)
       .then(({ data }) => data.sort(sortHooks))
       .then(setHooks)
       .catch(setError)
-      .catch(err => toast.error(`Could not list hooks: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list hooks: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [setLoading, context]);
 
   const emptyList = (
-    <EmptyList
-      icon={<HookIcon/>}
-      title="No hooks"
-    >
+    <EmptyList icon={<HookIcon />} title="No hooks">
       <p>There are no hooks yet</p>
       <Link to={`${url}/add`}>
         <button type="button" className="btn btn-primary">
@@ -50,9 +51,9 @@ export function HookList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       {hooks.length === 0 ? (
@@ -61,11 +62,14 @@ export function HookList() {
         <ul className="list-group">
           <Link
             to={`${url}/add`}
-            className={classNames('list-group-item list-group-item-action', styles.add)}
+            className={classNames(
+              "list-group-item list-group-item-action",
+              styles.add
+            )}
           >
             Add hook
           </Link>
-          {hooks.map(hook => (
+          {hooks.map((hook) => (
             <Link
               key={hook._id}
               to={`${url}/${hook._id}`}

--- a/ui/src/components/hooks/HookView.tsx
+++ b/ui/src/components/hooks/HookView.tsx
@@ -1,26 +1,30 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Route, Switch, useParams, useRouteMatch } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsisV, faTrashAlt } from '@fortawesome/free-solid-svg-icons';
-import { uniqueId } from 'lodash';
-import { Hook } from './hook';
-import { ButtonIcon } from '../../commons/components/ButtonIcon';
-import { routerHistory } from '../../providers/history';
-import { Dropdown, dropdownToggle } from '../../commons/components/dropdown/Dropdown';
-import { Loader } from '../../commons/components/Loader';
-import { DeleteHook } from './DeleteHook';
-import { DropdownLink } from '../../commons/components/dropdown/DropdownLink';
-import { SubHeader } from '../SubHeader';
-import { axios } from '../../providers/axios';
-import { AlertError } from '../../commons/components/AlertError';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { useHookContext } from './HookProvider';
-import { HookForm } from './form/HookForm';
-import { routeUp } from '../../commons/utils/route-up';
-import { NavPills } from '../../commons/components/NavPills';
-import { HookDeliveries } from './deliveries/HookDeliveries';
-import { NotFound } from '../../commons/components/NotFound';
+import React, { useCallback, useEffect, useState } from "react";
+import { Route, Switch, useParams, useRouteMatch } from "react-router-dom";
+import { toast } from "react-toastify";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEllipsisV, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
+import { uniqueId } from "lodash";
+import { Hook } from "./hook";
+import { ButtonIcon } from "../../commons/components/ButtonIcon";
+import { routerHistory } from "../../providers/history";
+import {
+  Dropdown,
+  dropdownToggle,
+} from "../../commons/components/dropdown/Dropdown";
+import { Loader } from "../../commons/components/Loader";
+import { DeleteHook } from "./DeleteHook";
+import { DropdownLink } from "../../commons/components/dropdown/DropdownLink";
+import { SubHeader } from "../SubHeader";
+import { axios } from "../../providers/axios";
+import { AlertError } from "../../commons/components/AlertError";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { useHookContext } from "./HookProvider";
+import { HookForm } from "./form/HookForm";
+import { routeUp } from "../../commons/utils/route-up";
+import { NavPills } from "../../commons/components/NavPills";
+import { HookDeliveries } from "./deliveries/HookDeliveries";
+import { NotFound } from "../../commons/components/NotFound";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function HookView() {
   const { hookId } = useParams<any>();
@@ -39,15 +43,18 @@ export function HookView() {
       .get<Hook>(`/api/v1/${context}/hooks/${hookId}`)
       .then(({ data }) => setHook(data))
       .catch(setError)
-      .catch(err => toast.error(`Could not get hook: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not get hook: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [setLoading, hookId, context]);
 
   const onChange = useCallback(
-    (formData: Hook): Promise<void> => axios
-      .put<Hook>(`/api/v1/${context}/hooks/${hookId}`, formData)
-      .then(({ data }) => setHook(data)),
-    [hookId, context],
+    (formData: Hook): Promise<void> =>
+      axios
+        .put<Hook>(`/api/v1/${context}/hooks/${hookId}`, formData)
+        .then(({ data }) => setHook(data)),
+    [hookId, context]
   );
 
   const onDelete = () => {
@@ -55,37 +62,38 @@ export function HookView() {
   };
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       <SubHeader className="d-flex align-items-center justify-content-between">
         <div className="d-flex align-items-center">
           <code className="mr-2">{hook.type}</code>
-          <h5 className="mb-0 d-flex align-items-center">
-            {hook.name}
-          </h5>
+          <h5 className="mb-0 d-flex align-items-center">{hook.name}</h5>
         </div>
         <div className="d-flex align-items-center">
-          <NavPills links={[
-            {
-              to: url,
-              label: 'Settings',
-              exact: true,
-            },
-            {
-              to: `${url}/deliveries`,
-              label: 'Deliveries',
-            },
-          ]}
+          <NavPills
+            links={[
+              {
+                to: url,
+                label: "Settings",
+                exact: true,
+              },
+              {
+                to: `${url}/deliveries`,
+                label: "Deliveries",
+              },
+            ]}
           />
           <ButtonIcon className="ml-3" {...dropdownToggle(uid)}>
-            <FontAwesomeIcon icon={faEllipsisV}/>
+            <FontAwesomeIcon icon={faEllipsisV} />
           </ButtonIcon>
           <Dropdown id={uid}>
             <DeleteHook hookId={hookId} onDelete={onDelete}>
-              <DropdownLink icon={<FontAwesomeIcon icon={faTrashAlt} fixedWidth/>}>
+              <DropdownLink
+                icon={<FontAwesomeIcon icon={faTrashAlt} fixedWidth />}
+              >
                 Delete
               </DropdownLink>
             </DeleteHook>
@@ -97,15 +105,10 @@ export function HookView() {
         <Route
           path={path}
           exact
-          component={() => (
-            <HookForm
-              value={hook}
-              onChange={onChange}
-            />
-          )}
+          component={() => <HookForm value={hook} onChange={onChange} />}
         />
-        <Route path={`${path}/deliveries`} exact component={HookDeliveries}/>
-        <Route component={NotFound}/>
+        <Route path={`${path}/deliveries`} exact component={HookDeliveries} />
+        <Route component={NotFound} />
       </Switch>
     </>
   );

--- a/ui/src/components/hooks/TestHook.tsx
+++ b/ui/src/components/hooks/TestHook.tsx
@@ -1,12 +1,15 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Button } from '../../commons/components/Button';
-import { axios } from '../../providers/axios';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Button } from "../../commons/components/Button";
+import { axios } from "../../providers/axios";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function TestHook({
-  config, className, disabled,
+  config,
+  className,
+  disabled,
 }: {
   config: any;
   className?: string;
@@ -17,8 +20,8 @@ export function TestHook({
     setLoading(true);
     axios
       .post(`/api/v1/sites/notifications/test`, config)
-      .then(() => toast.success('It worked !'))
-      .catch(err => toast.error(`It didnt work: ${err}`))
+      .then(() => toast.success("It worked !"))
+      .catch((err) => toast.error(`It didnt work: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
   return (
@@ -27,7 +30,7 @@ export function TestHook({
         loading={loading}
         onClick={test}
         disabled={disabled}
-        className={classNames('btn btn-sm btn-primary', className)}
+        className={classNames("btn btn-sm btn-primary", className)}
       >
         Test
       </Button>

--- a/ui/src/components/hooks/deliveries/HookDeliveries.tsx
+++ b/ui/src/components/hooks/deliveries/HookDeliveries.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { useHookContext } from '../HookProvider';
-import { PaginationData } from '../../../commons/components/Pagination';
-import { LoadMore } from '../../../commons/components/LoadMore';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../providers/axios';
-import { HookDeliveryView } from './HookDeliveryView';
-import { HookDelivery } from './hook-delivery';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { HookDeliveryIcon } from '../../icons/HookDeliveryIcon';
+import React, { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { useHookContext } from "../HookProvider";
+import { PaginationData } from "../../../commons/components/Pagination";
+import { LoadMore } from "../../../commons/components/LoadMore";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../providers/axios";
+import { HookDeliveryView } from "./HookDeliveryView";
+import { HookDelivery } from "./hook-delivery";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { HookDeliveryIcon } from "../../icons/HookDeliveryIcon";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function HookDeliveries() {
   const { context } = useHookContext();
@@ -21,7 +22,8 @@ export function HookDeliveries() {
   const [deliveries, setDeliveries] = useState<HookDelivery[]>();
   const itemsRef = useRef<HookDelivery[]>([]);
   const [pagination, setPagination] = useState<PaginationData>({
-    page: 0, size: 10,
+    page: 0,
+    size: 10,
   });
   const [hasMore, setHasMore] = useState(false);
 
@@ -38,7 +40,11 @@ export function HookDeliveries() {
         setHasMore(data.count > itemsRef.current.length);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list hook deliveries: ${err}`))
+      .catch((err) =>
+        toast.error(
+          `Could not list hook deliveries: ${extractErrorMessage(err)}`
+        )
+      )
       .finally(() => setLoading(false));
   }, [pagination, hookId, setLoading, context]);
 
@@ -54,23 +60,19 @@ export function HookDeliveries() {
       {deliveries && (
         <div>
           {deliveries.length === 0 ? (
-            <EmptyList
-              icon={<HookDeliveryIcon/>}
-              title="No sites"
-            />
+            <EmptyList icon={<HookDeliveryIcon />} title="No sites" />
           ) : (
             <ul className="list-group">
-              {deliveries.map(hookDelivery => (
-                <HookDeliveryView delivery={hookDelivery} key={hookDelivery._id}/>
+              {deliveries.map((hookDelivery) => (
+                <HookDeliveryView
+                  delivery={hookDelivery}
+                  key={hookDelivery._id}
+                />
               ))}
             </ul>
           )}
-          {loading && (
-            <Loader/>
-          )}
-          {error && (
-            <AlertError error={error}/>
-          )}
+          {loading && <Loader />}
+          {error && <AlertError error={error} />}
           {hasMore && (
             <div className="d-flex justify-content-center mt-4">
               <LoadMore

--- a/ui/src/components/hooks/form/HookEvents.tsx
+++ b/ui/src/components/hooks/form/HookEvents.tsx
@@ -1,12 +1,13 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { Controller, useFormContext } from 'react-hook-form';
-import { useHookContext } from '../HookProvider';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../providers/axios';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { Toggle } from '../../../commons/components/forms/Toggle';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { Controller, useFormContext } from "react-hook-form";
+import { useHookContext } from "../HookProvider";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../providers/axios";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { Toggle } from "../../../commons/components/forms/Toggle";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function HookEvents() {
   const { context } = useHookContext();
@@ -19,18 +20,21 @@ export function HookEvents() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get<string[]>(`/api/v1/${context}/hook-events`)
+    axios
+      .get<string[]>(`/api/v1/${context}/hook-events`)
       .then(({ data }) => data)
       .then(setEvents)
       .catch(setError)
-      .catch(err => toast.error(`Could not list hook events: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list hook events: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [setLoading, context]);
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <Controller
       control={control}
@@ -41,13 +45,17 @@ export function HookEvents() {
           {events.length === 0 ? (
             <>No events to show</>
           ) : (
-            events.map(event => (
+            events.map((event) => (
               <Toggle
                 key={event}
                 className="list-group-item"
                 value={value.includes(event)}
-                onChange={isOn => {
-                  onChange(isOn ? [event, ...value] : value.filter(ev => ev !== event));
+                onChange={(isOn) => {
+                  onChange(
+                    isOn
+                      ? [event, ...value]
+                      : value.filter((ev) => ev !== event)
+                  );
                 }}
               >
                 <strong>{event}</strong>

--- a/ui/src/components/invites/AcceptInvite.tsx
+++ b/ui/src/components/invites/AcceptInvite.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Button } from '../../commons/components/Button';
-import { axios } from '../../providers/axios';
-import { UserOrg } from '../auth/user-org';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Button } from "../../commons/components/Button";
+import { axios } from "../../providers/axios";
+import { UserOrg } from "../auth/user-org";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function AcceptInvite({
-  inviteId, className, onAccept, token, disabled,
+  inviteId,
+  className,
+  onAccept,
+  token,
+  disabled,
 }: {
   token: string;
   inviteId: string;
@@ -25,8 +30,8 @@ export function AcceptInvite({
       })
       .then(({ data }) => data)
       .then(onAccept)
-      .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -35,7 +40,7 @@ export function AcceptInvite({
     <>
       <Button
         onClick={accept}
-        className={classNames(className, 'btn btn-success')}
+        className={classNames(className, "btn btn-success")}
         loading={loading}
         disabled={disabled}
       >

--- a/ui/src/components/invites/DeclineInvite.tsx
+++ b/ui/src/components/invites/DeclineInvite.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Button } from '../../commons/components/Button';
-import { axios } from '../../providers/axios';
-import { UserOrg } from '../auth/user-org';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Button } from "../../commons/components/Button";
+import { axios } from "../../providers/axios";
+import { UserOrg } from "../auth/user-org";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function DeclineInvite({
-  inviteId, className, onIgnore, token, disabled,
+  inviteId,
+  className,
+  onIgnore,
+  token,
+  disabled,
 }: {
   inviteId: string;
   token: string;
@@ -24,8 +29,8 @@ export function DeclineInvite({
         token,
       })
       .then(() => onIgnore())
-      .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -34,7 +39,7 @@ export function DeclineInvite({
     <>
       <Button
         onClick={accept}
-        className={classNames(className, 'btn btn-danger')}
+        className={classNames(className, "btn btn-danger")}
         loading={loading}
         disabled={disabled}
       >

--- a/ui/src/components/orgs/AddOrg.tsx
+++ b/ui/src/components/orgs/AddOrg.tsx
@@ -1,28 +1,35 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { uniqueId } from 'lodash';
-import { FormProvider, useForm } from 'react-hook-form';
-import { axios } from '../../providers/axios';
-import { Tooltip, tooltipToggle } from '../../commons/components/Tooltip';
-import { OrgNameInput } from './settings/OrgNameInput';
-import { Button } from '../../commons/components/Button';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { UserOrg } from '../auth/user-org';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { uniqueId } from "lodash";
+import { FormProvider, useForm } from "react-hook-form";
+import { axios } from "../../providers/axios";
+import { Tooltip, tooltipToggle } from "../../commons/components/Tooltip";
+import { OrgNameInput } from "./settings/OrgNameInput";
+import { Button } from "../../commons/components/Button";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { UserOrg } from "../auth/user-org";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 interface Form {
   name: string;
 }
 
-function Modal({ closeModal, onAdded }: {
+function Modal({
+  closeModal,
+  onAdded,
+}: {
   closeModal;
   onAdded: (org: UserOrg) => void;
 }) {
   const methods = useForm<Form>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
   const onSubmit = (form: Form) => {
     setLoading(true);
@@ -34,8 +41,8 @@ function Modal({ closeModal, onAdded }: {
       .finally(() => {
         closeModal();
       })
-      .catch(err => {
-        toast.error(`Could not create org: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not create org: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -51,7 +58,7 @@ function Modal({ closeModal, onAdded }: {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <OrgNameInput setInputRef={setInputRef}/>
+        <OrgNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -68,7 +75,10 @@ function Modal({ closeModal, onAdded }: {
 }
 
 export function AddOrg({
-  children, className, tooltip = true, onAdded,
+  children,
+  className,
+  tooltip = true,
+  onAdded,
 }: {
   children;
   className?;
@@ -82,20 +92,12 @@ export function AddOrg({
 
   return (
     <>
-      <div
-        onClick={openModal}
-        className={className}
-        {...tooltipToggle(uid)}
-      >
+      <div onClick={openModal} className={className} {...tooltipToggle(uid)}>
         {children}
       </div>
-      {tooltip && (
-        <Tooltip id={uid}>
-          Create org
-        </Tooltip>
-      )}
+      {tooltip && <Tooltip id={uid}>Create org</Tooltip>}
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Create org">
-        <Modal closeModal={closeModal} onAdded={onAdded}/>
+        <Modal closeModal={closeModal} onAdded={onAdded} />
       </CardModal>
     </>
   );

--- a/ui/src/components/orgs/settings/OrgGeneralSettings.tsx
+++ b/ui/src/components/orgs/settings/OrgGeneralSettings.tsx
@@ -1,15 +1,19 @@
-import { FormProvider, useForm } from 'react-hook-form';
-import React, { useEffect } from 'react';
-import { toast } from 'react-toastify';
-import styles from './OrgSettings.module.scss';
-import { Button } from '../../../commons/components/Button';
-import { OrgNameInput } from './OrgNameInput';
-import { axios } from '../../../providers/axios';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { COLOR_PATTERN, required } from '../../../commons/components/forms/form-constants';
-import { useOrg } from '../OrgView';
-import { Org } from '../org';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { FormProvider, useForm } from "react-hook-form";
+import React, { useEffect } from "react";
+import { toast } from "react-toastify";
+import styles from "./OrgSettings.module.scss";
+import { Button } from "../../../commons/components/Button";
+import { OrgNameInput } from "./OrgNameInput";
+import { axios } from "../../../providers/axios";
+import { InputError } from "../../../commons/components/forms/InputError";
+import {
+  COLOR_PATTERN,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { useOrg } from "../OrgView";
+import { Org } from "../org";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface Settings {
   name: string;
@@ -20,10 +24,14 @@ export function OrgGeneralSettings() {
   const { org, setOrg } = useOrg();
 
   const methods = useForm<Settings>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const {
-    errors, register, reset, handleSubmit, formState: { isDirty },
+    errors,
+    register,
+    reset,
+    handleSubmit,
+    formState: { isDirty },
   } = methods;
 
   useEffect(() => {
@@ -40,26 +48,26 @@ export function OrgGeneralSettings() {
       .put<Org>(`/api/v1/orgs/${org._id}`, settings)
       .then(({ data }) => data)
       .then(setOrg)
-      .then(() => toast.success('Org saved'))
-      .catch(err => toast.error(`Could not update org: ${err}`))
+      .then(() => toast.success("Org saved"))
+      .catch((err) =>
+        toast.error(`Could not update org: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   };
 
   return (
     <FormProvider {...methods}>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className={styles.form}
-      >
-
+      <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <div className="mt-4 card">
           <div className="card-header">
             <strong>General settings</strong>
           </div>
           <div className="card-body">
-            <OrgNameInput/>
+            <OrgNameInput />
             <div className="form-group">
-              <label htmlFor="color" className="form-label">Color</label>
+              <label htmlFor="color" className="form-label">
+                Color
+              </label>
               <input
                 type="color"
                 id="color"
@@ -72,7 +80,7 @@ export function OrgGeneralSettings() {
                 autoComplete="off"
                 defaultValue="#000000"
               />
-              <InputError error={errors} path="color"/>
+              <InputError error={errors} path="color" />
             </div>
           </div>
         </div>
@@ -97,7 +105,6 @@ export function OrgGeneralSettings() {
             Save
           </Button>
         </div>
-
       </form>
     </FormProvider>
   );

--- a/ui/src/components/orgs/staff/invites/AddInvite.tsx
+++ b/ui/src/components/orgs/staff/invites/AddInvite.tsx
@@ -1,45 +1,58 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Controller, useForm } from 'react-hook-form';
-import { Button } from '../../../../commons/components/Button';
-import { axios } from '../../../../providers/axios';
-import { CardModal } from '../../../../commons/components/modals/CardModal';
-import { isEmail, maxLength, required } from '../../../../commons/components/forms/form-constants';
-import { InputError } from '../../../../commons/components/forms/InputError';
-import styles from './AddInvite.module.scss';
-import { OrgMember } from '../members/org-member';
-import { useCurrentOrg } from '../../../../providers/OrgProvider';
-import { Toggle } from '../../../../commons/components/forms/Toggle';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Controller, useForm } from "react-hook-form";
+import { Button } from "../../../../commons/components/Button";
+import { axios } from "../../../../providers/axios";
+import { CardModal } from "../../../../commons/components/modals/CardModal";
+import {
+  isEmail,
+  maxLength,
+  required,
+} from "../../../../commons/components/forms/form-constants";
+import { InputError } from "../../../../commons/components/forms/InputError";
+import styles from "./AddInvite.module.scss";
+import { OrgMember } from "../members/org-member";
+import { useCurrentOrg } from "../../../../providers/OrgProvider";
+import { Toggle } from "../../../../commons/components/forms/Toggle";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 interface InviteRequest {
   email: string;
   admin: boolean;
 }
 
-function AddMemberModal({ closeModal, onAdded }: {
+function AddMemberModal({
+  closeModal,
+  onAdded,
+}: {
   closeModal;
   onAdded: (member: OrgMember) => void;
 }) {
   const { currentOrg } = useCurrentOrg();
   const {
-    register, errors, handleSubmit, formState: { isDirty }, control,
+    register,
+    errors,
+    handleSubmit,
+    formState: { isDirty },
+    control,
   } = useForm<InviteRequest>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
 
-  const onChange = (member: InviteRequest) => axios
-    .post(`/api/v1/orgs/${currentOrg.org._id}/invites`, member)
-    .then(({ data }) => {
-      onAdded(data);
-    })
-    .then(closeModal)
-    .catch(err => {
-      toast.error(`Could not add invite: ${err}`);
-    });
+  const onChange = (member: InviteRequest) =>
+    axios
+      .post(`/api/v1/orgs/${currentOrg.org._id}/invites`, member)
+      .then(({ data }) => {
+        onAdded(data);
+      })
+      .then(closeModal)
+      .catch((err) => {
+        toast.error(`Could not add invite: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -61,7 +74,7 @@ function AddMemberModal({ closeModal, onAdded }: {
           placeholder="steve@apple.com"
           autoComplete="off"
         />
-        <InputError error={errors} path="email"/>
+        <InputError error={errors} path="email" />
       </div>
       <div className="form-group flex-grow-1 col">
         <Controller
@@ -73,13 +86,9 @@ function AddMemberModal({ closeModal, onAdded }: {
             maxLength: maxLength(),
           })}
           defaultValue={false}
-          as={(
-            <Toggle>
-              Admin
-            </Toggle>
-          )}
+          as={<Toggle>Admin</Toggle>}
         />
-        <InputError error={errors} path="admin"/>
+        <InputError error={errors} path="admin" />
       </div>
       <div className="d-flex justify-content-end">
         <Button
@@ -96,7 +105,9 @@ function AddMemberModal({ closeModal, onAdded }: {
 }
 
 export function AddInvite({
-  children, className, onAdded,
+  children,
+  className,
+  onAdded,
 }: {
   children;
   className?;
@@ -111,8 +122,12 @@ export function AddInvite({
       <div onClick={openModal} className={className}>
         {children}
       </div>
-      <CardModal isOpen={isOpen} closeModal={closeModal} title="Invite org member">
-        <AddMemberModal closeModal={closeModal} onAdded={onAdded}/>
+      <CardModal
+        isOpen={isOpen}
+        closeModal={closeModal}
+        title="Invite org member"
+      >
+        <AddMemberModal closeModal={closeModal} onAdded={onAdded} />
       </CardModal>
     </>
   );

--- a/ui/src/components/orgs/staff/invites/DeleteInvite.tsx
+++ b/ui/src/components/orgs/staff/invites/DeleteInvite.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../../commons/components/Button';
-import { axios } from '../../../../providers/axios';
-import { CardModal } from '../../../../commons/components/modals/CardModal';
-import { useCurrentOrg } from '../../../../providers/OrgProvider';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../../commons/components/Button";
+import { axios } from "../../../../providers/axios";
+import { CardModal } from "../../../../commons/components/modals/CardModal";
+import { useCurrentOrg } from "../../../../providers/OrgProvider";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function DeleteInvite({
-  inviteId, className, children, onDelete,
+  inviteId,
+  className,
+  children,
+  onDelete,
 }: {
   inviteId: string;
   children: any;
@@ -26,8 +30,8 @@ export function DeleteInvite({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/staff/invites/Invites.tsx
+++ b/ui/src/components/orgs/staff/invites/Invites.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPaperPlane } from '@fortawesome/free-regular-svg-icons';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { Loader } from '../../../../commons/components/Loader';
-import { AlertError } from '../../../../commons/components/AlertError';
-import { Invite } from './invite';
-import { axios } from '../../../../providers/axios';
-import { InviteView } from './InviteView';
-import { AddInvite } from './AddInvite';
-import { useCurrentOrg } from '../../../../providers/OrgProvider';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { ButtonIcon } from '../../../../commons/components/ButtonIcon';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPaperPlane } from "@fortawesome/free-regular-svg-icons";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { Loader } from "../../../../commons/components/Loader";
+import { AlertError } from "../../../../commons/components/AlertError";
+import { Invite } from "./invite";
+import { axios } from "../../../../providers/axios";
+import { InviteView } from "./InviteView";
+import { AddInvite } from "./AddInvite";
+import { useCurrentOrg } from "../../../../providers/OrgProvider";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { ButtonIcon } from "../../../../commons/components/ButtonIcon";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 function sortInvites(a: Invite, b: Invite): number {
   return new Date(b.expiresAt).getTime() - new Date(a.expiresAt).getTime();
@@ -26,15 +27,18 @@ export function Invites() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get(`/api/v1/orgs/${currentOrg.org._id}/invites`)
+    axios
+      .get(`/api/v1/orgs/${currentOrg.org._id}/invites`)
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list invites: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list invites: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [currentOrg, setLoading]);
 
-  const onAdd = invite => {
+  const onAdd = (invite) => {
     setItems([invite, ...items].sort(sortInvites));
   };
 
@@ -46,25 +50,25 @@ export function Invites() {
     <div className="mt-4 card">
       <div className="card-header d-flex justify-content-between">
         <div>
-          <FontAwesomeIcon icon={faPaperPlane} className="mr-2"/>
+          <FontAwesomeIcon icon={faPaperPlane} className="mr-2" />
           <strong>Invites</strong>
         </div>
         <AddInvite onAdded={onAdd}>
           <ButtonIcon>
-            <FontAwesomeIcon icon={faPlus}/>
+            <FontAwesomeIcon icon={faPlus} />
           </ButtonIcon>
         </AddInvite>
       </div>
       <div className="card-body">
         {loading ? (
-          <Loader/>
+          <Loader />
         ) : error ? (
-          <AlertError error={error}/>
+          <AlertError error={error} />
         ) : items.length === 0 ? (
           <div className="text-center">No invites to show</div>
         ) : (
           <ul className="list-group">
-            {items.map(invite => (
+            {items.map((invite) => (
               <InviteView
                 key={invite._id}
                 invite={invite}

--- a/ui/src/components/orgs/staff/members/DeleteMember.tsx
+++ b/ui/src/components/orgs/staff/members/DeleteMember.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../../commons/components/Button';
-import { axios } from '../../../../providers/axios';
-import { CardModal } from '../../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../../commons/components/Button";
+import { axios } from "../../../../providers/axios";
+import { CardModal } from "../../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function DeleteMember({
-  memberId, className, children, onDelete,
+  memberId,
+  className,
+  children,
+  onDelete,
 }: {
   memberId: string;
   children: any;
@@ -24,8 +28,8 @@ export function DeleteMember({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete member: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete member: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/staff/members/MemberView.tsx
+++ b/ui/src/components/orgs/staff/members/MemberView.tsx
@@ -1,22 +1,29 @@
-import React, { useState } from 'react';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
-import { uniqueId } from 'lodash';
-import { toast } from 'react-toastify';
-import { OrgMember } from './org-member';
-import { DeleteMember } from './DeleteMember';
-import { ButtonIcon } from '../../../../commons/components/ButtonIcon';
-import { Toggle } from '../../../../commons/components/forms/Toggle';
-import { Dropdown, dropdownToggle } from '../../../../commons/components/dropdown/Dropdown';
-import { axios } from '../../../../providers/axios';
-import { useCurrentOrg } from '../../../../providers/OrgProvider';
-import { Loader } from '../../../../commons/components/Loader';
-import { DropdownLink } from '../../../../commons/components/dropdown/DropdownLink';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { IsOwner } from '../../../auth/IsOwner';
+import React, { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrashAlt } from "@fortawesome/free-regular-svg-icons";
+import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
+import { uniqueId } from "lodash";
+import { toast } from "react-toastify";
+import { OrgMember } from "./org-member";
+import { DeleteMember } from "./DeleteMember";
+import { ButtonIcon } from "../../../../commons/components/ButtonIcon";
+import { Toggle } from "../../../../commons/components/forms/Toggle";
+import {
+  Dropdown,
+  dropdownToggle,
+} from "../../../../commons/components/dropdown/Dropdown";
+import { axios } from "../../../../providers/axios";
+import { useCurrentOrg } from "../../../../providers/OrgProvider";
+import { Loader } from "../../../../commons/components/Loader";
+import { DropdownLink } from "../../../../commons/components/dropdown/DropdownLink";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { IsOwner } from "../../../auth/IsOwner";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
-function AdminToggle({ member, setMember }: {
+function AdminToggle({
+  member,
+  setMember,
+}: {
   member: OrgMember;
   setMember: (member: OrgMember) => void;
 }) {
@@ -30,8 +37,8 @@ function AdminToggle({ member, setMember }: {
       })
       .then(({ data }) => data)
       .then(setMember)
-      .catch(err => {
-        toast.error(`Could not toggle admin: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not toggle admin: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -43,16 +50,16 @@ function AdminToggle({ member, setMember }: {
       onChange={toggle}
       disabled={loading}
     >
-      {loading && (
-        <Loader className="mr-2"/>
-      )}
+      {loading && <Loader className="mr-2" />}
       admin
     </Toggle>
   );
 }
 
 export function MemberView({
-  member, setMember, onDelete,
+  member,
+  setMember,
+  onDelete,
 }: {
   member: OrgMember;
   setMember: (member: OrgMember) => void;
@@ -66,9 +73,7 @@ export function MemberView({
       <div className="flex-grow-1 d-flex align-items-center">
         <strong className="mr-3">{member.name}</strong>
         <span className="text-muted">{member.email}</span>
-        {member.owner && (
-          <span className="badge badge-danger ml-3">owner</span>
-        )}
+        {member.owner && <span className="badge badge-danger ml-3">owner</span>}
         {currentOrg.member._id === member._id && (
           <span className="badge badge-success ml-2">you</span>
         )}
@@ -77,17 +82,17 @@ export function MemberView({
       <div className="d-flex align-items-center">
         <IsOwner>
           {!member.owner && (
-            <AdminToggle
-              member={member}
-              setMember={setMember}
-            />
+            <AdminToggle member={member} setMember={setMember} />
           )}
           <ButtonIcon className="ml-3" {...dropdownToggle(uid)}>
-            <FontAwesomeIcon icon={faEllipsisV}/>
+            <FontAwesomeIcon icon={faEllipsisV} />
           </ButtonIcon>
           <Dropdown id={uid}>
             <DeleteMember memberId={member._id} onDelete={onDelete}>
-              <DropdownLink icon={<FontAwesomeIcon icon={faTrashAlt}/>} disabled={member.owner}>
+              <DropdownLink
+                icon={<FontAwesomeIcon icon={faTrashAlt} />}
+                disabled={member.owner}
+              >
                 Delete
               </DropdownLink>
             </DeleteMember>

--- a/ui/src/components/orgs/staff/members/Members.tsx
+++ b/ui/src/components/orgs/staff/members/Members.tsx
@@ -1,15 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
-import { AlertError } from '../../../../commons/components/AlertError';
-import { LoadMore } from '../../../../commons/components/LoadMore';
-import { SearchInput } from '../../../sites/releases/SearchInput';
-import { useOrg } from '../../OrgView';
-import { getMembers, OrgMembersSearchQuery } from './get-members';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { MemberView } from './MemberView';
-import { OrgMember } from './org-member';
-import { OrgMemberIcon } from '../../../icons/OrgMemberIcon';
-import { Loader } from '../../../../commons/components/Loader';
+import React, { useEffect, useRef, useState } from "react";
+import { toast } from "react-toastify";
+import { AlertError } from "../../../../commons/components/AlertError";
+import { LoadMore } from "../../../../commons/components/LoadMore";
+import { SearchInput } from "../../../sites/releases/SearchInput";
+import { useOrg } from "../../OrgView";
+import { getMembers, OrgMembersSearchQuery } from "./get-members";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { MemberView } from "./MemberView";
+import { OrgMember } from "./org-member";
+import { OrgMemberIcon } from "../../../icons/OrgMemberIcon";
+import { Loader } from "../../../../commons/components/Loader";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function Members() {
   const [loading, setLoading] = useMountedState(true);
@@ -20,12 +21,16 @@ export function Members() {
   const itemsRef = useRef<OrgMember[]>([]);
   const [canLoadMore, setCanLoadMore] = useState(false);
   const [searching, setSearching] = useState(false);
-  const previousSearch = useRef('');
-  const [search, setSearch] = useState('');
+  const previousSearch = useRef("");
+  const [search, setSearch] = useState("");
   const searchQueryRef = useRef({
-    search: '', page: 0, size: 10,
+    search: "",
+    page: 0,
+    size: 10,
   });
-  const [searchQuery, setSearchQuery] = useState<OrgMembersSearchQuery>(searchQueryRef.current);
+  const [searchQuery, setSearchQuery] = useState<OrgMembersSearchQuery>(
+    searchQueryRef.current
+  );
 
   useEffect(() => {
     // prevents duplicate calls when search input is initialized
@@ -69,13 +74,17 @@ export function Members() {
     setError(undefined);
 
     getMembers(org._id, searchQuery)
-      .then(data => {
-        itemsRef.current = searchQuery.search ? data.items : [...itemsRef.current, ...data.items];
+      .then((data) => {
+        itemsRef.current = searchQuery.search
+          ? data.items
+          : [...itemsRef.current, ...data.items];
         setItems(itemsRef.current);
         setCanLoadMore(itemsRef.current.length !== data.count);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list members: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list members: ${extractErrorMessage(err)}`)
+      )
       .finally(() => {
         setSearching(false);
         setLoading(false);
@@ -94,7 +103,7 @@ export function Members() {
   };
 
   const onEdit = (member: OrgMember) => {
-    setItems(items.map(item => (item._id === member._id ? member : item)));
+    setItems(items.map((item) => (item._id === member._id ? member : item)));
   };
 
   return (
@@ -102,7 +111,7 @@ export function Members() {
       <div className="mt-4 card">
         <div className="card-header d-flex justify-content-between">
           <div>
-            <OrgMemberIcon className="mr-2"/>
+            <OrgMemberIcon className="mr-2" />
             <strong>Members</strong>
           </div>
           <div>
@@ -116,14 +125,14 @@ export function Members() {
         </div>
         <div className="card-body">
           {loading ? (
-            <Loader/>
+            <Loader />
           ) : error ? (
-            <AlertError error={error}/>
+            <AlertError error={error} />
           ) : items.length === 0 ? (
             <>No search results found</>
           ) : (
             <ul className="list-group">
-              {items.map(member => (
+              {items.map((member) => (
                 <MemberView
                   key={member._id}
                   member={member}
@@ -138,9 +147,7 @@ export function Members() {
                   disabled={loading}
                 />
               )}
-              {error && (
-                <AlertError error={error} className="mt-4"/>
-              )}
+              {error && <AlertError error={error} className="mt-4" />}
             </ul>
           )}
         </div>

--- a/ui/src/components/projects/AddProject.tsx
+++ b/ui/src/components/projects/AddProject.tsx
@@ -1,49 +1,57 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { uniqueId } from 'lodash';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useShortcut } from '../../commons/keyboard/use-shortcut';
-import { ADD_PROJECT_SHORTCUT_KEY } from '../../commons/keyboard/shortcuts-keys';
-import { axios } from '../../providers/axios';
-import { routerHistory } from '../../providers/history';
-import { Tooltip, tooltipToggle } from '../../commons/components/Tooltip';
-import { ProjectNameInput } from './settings/ProjectNameInput';
-import { Button } from '../../commons/components/Button';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { KeyboardShortcut } from '../../commons/components/KeyboardShortcut';
-import { isMac, isWindows } from '../../commons/utils/os';
-import { Project } from './project';
-import { useCurrentOrg } from '../../providers/OrgProvider';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { IsAdmin } from '../auth/IsAdmin';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { uniqueId } from "lodash";
+import { FormProvider, useForm } from "react-hook-form";
+import { useShortcut } from "../../commons/keyboard/use-shortcut";
+import { ADD_PROJECT_SHORTCUT_KEY } from "../../commons/keyboard/shortcuts-keys";
+import { axios } from "../../providers/axios";
+import { routerHistory } from "../../providers/history";
+import { Tooltip, tooltipToggle } from "../../commons/components/Tooltip";
+import { ProjectNameInput } from "./settings/ProjectNameInput";
+import { Button } from "../../commons/components/Button";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { KeyboardShortcut } from "../../commons/components/KeyboardShortcut";
+import { isMac, isWindows } from "../../commons/utils/os";
+import { Project } from "./project";
+import { useCurrentOrg } from "../../providers/OrgProvider";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { IsAdmin } from "../auth/IsAdmin";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
-function AddProjectModal({ closeModal, onAdded }: {
+function AddProjectModal({
+  closeModal,
+  onAdded,
+}: {
   closeModal;
   onAdded?: (project: Project) => void;
 }) {
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
   const { currentOrg } = useCurrentOrg();
 
-  const onChange = formData => axios
-    .post<Project>(`/api/v1/orgs/${currentOrg.org._id}/projects`, formData)
-    .then(({ data }) => {
-      if (onAdded) {
-        onAdded(data);
-      }
-      routerHistory.push(`/projects/${data._id}`);
-    })
-    .finally(() => {
-      closeModal();
-    })
-    .catch(err => {
-      toast.error(`Could not create project: ${err}`);
-    });
+  const onChange = (formData) =>
+    axios
+      .post<Project>(`/api/v1/orgs/${currentOrg.org._id}/projects`, formData)
+      .then(({ data }) => {
+        if (onAdded) {
+          onAdded(data);
+        }
+        routerHistory.push(`/projects/${data._id}`);
+      })
+      .finally(() => {
+        closeModal();
+      })
+      .catch((err) => {
+        toast.error(`Could not create project: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -59,7 +67,7 @@ function AddProjectModal({ closeModal, onAdded }: {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <ProjectNameInput setInputRef={setInputRef}/>
+        <ProjectNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -76,7 +84,10 @@ function AddProjectModal({ closeModal, onAdded }: {
 }
 
 export function AddProject({
-  children, className, tooltip = true, onAdded,
+  children,
+  className,
+  tooltip = true,
+  onAdded,
 }: {
   children;
   className?;
@@ -90,16 +101,12 @@ export function AddProject({
 
   useShortcut(ADD_PROJECT_SHORTCUT_KEY, () => setIsOpen(true));
 
-  const shortCut = isMac() ? '⌘' : isWindows() ? 'Ctrl' : undefined;
+  const shortCut = isMac() ? "⌘" : isWindows() ? "Ctrl" : undefined;
 
   return (
     <>
       <IsAdmin>
-        <div
-          onClick={openModal}
-          className={className}
-          {...tooltipToggle(uid)}
-        >
+        <div onClick={openModal} className={className} {...tooltipToggle(uid)}>
           {children}
         </div>
       </IsAdmin>
@@ -108,21 +115,17 @@ export function AddProject({
           Add project
           {shortCut && (
             <>
-              {' '}
+              {" "}
               -
               <KeyboardShortcut className="ml-2" icon={false}>
-                {shortCut}
-                {' '}
-                +
-                {' '}
-                {ADD_PROJECT_SHORTCUT_KEY}
+                {shortCut} + {ADD_PROJECT_SHORTCUT_KEY}
               </KeyboardShortcut>
             </>
           )}
         </Tooltip>
       )}
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Add project">
-        <AddProjectModal closeModal={closeModal} onAdded={onAdded}/>
+        <AddProjectModal closeModal={closeModal} onAdded={onAdded} />
       </CardModal>
     </>
   );

--- a/ui/src/components/projects/DeleteProject.tsx
+++ b/ui/src/components/projects/DeleteProject.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { axios } from '../../providers/axios';
-import { routerHistory } from '../../providers/history';
-import { Button } from '../../commons/components/Button';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { IsAdmin } from '../auth/IsAdmin';
+import React from "react";
+import { toast } from "react-toastify";
+import { axios } from "../../providers/axios";
+import { routerHistory } from "../../providers/history";
+import { Button } from "../../commons/components/Button";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { IsAdmin } from "../auth/IsAdmin";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function DeleteProject({
-  id, className, children,
+  id,
+  className,
+  children,
 }: {
   id: string;
   className?: string;
@@ -23,10 +26,10 @@ export function DeleteProject({
       .delete(`/api/v1/projects/${id}`)
       .then(() => {
         setIsOpen(false);
-        routerHistory.push('/');
+        routerHistory.push("/");
       })
-      .catch(err => {
-        toast.error(`Could not delete project: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete project: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -38,7 +41,10 @@ export function DeleteProject({
         title="Delete project"
         closeModal={() => setIsOpen(false)}
       >
-        <p>Are you sure you want to delete this project ? Sites and related data (releases, branches, etc.) will be deleted.</p>
+        <p>
+          Are you sure you want to delete this project ? Sites and related data
+          (releases, branches, etc.) will be deleted.
+        </p>
         <div className="d-flex align-items-center">
           <button
             className="btn btn-outline-primary"

--- a/ui/src/components/projects/ProjectList.tsx
+++ b/ui/src/components/projects/ProjectList.tsx
@@ -1,23 +1,24 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { uniqueId } from 'lodash';
-import { Loader } from '../../commons/components/Loader';
-import { EmptyList } from '../../commons/components/EmptyList';
-import { AlertError } from '../../commons/components/AlertError';
-import { Project } from './project';
-import { PaginationData } from '../../commons/components/Pagination';
-import { LoadMore } from '../../commons/components/LoadMore';
-import { axios } from '../../providers/axios';
-import { ProjectIcon } from '../icons/ProjectIcon';
-import { Bubble } from '../../commons/components/Bubble';
-import { FromNow } from '../../commons/components/FromNow';
-import { AddProject } from './AddProject';
-import { useCurrentOrg } from '../../providers/OrgProvider';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { useRoom } from '../../websockets/use-room';
-import { EventType } from '../../websockets/event-type';
-import { Org } from '../orgs/org';
+import React, { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { toast } from "react-toastify";
+import { uniqueId } from "lodash";
+import { Loader } from "../../commons/components/Loader";
+import { EmptyList } from "../../commons/components/EmptyList";
+import { AlertError } from "../../commons/components/AlertError";
+import { Project } from "./project";
+import { PaginationData } from "../../commons/components/Pagination";
+import { LoadMore } from "../../commons/components/LoadMore";
+import { axios } from "../../providers/axios";
+import { ProjectIcon } from "../icons/ProjectIcon";
+import { Bubble } from "../../commons/components/Bubble";
+import { FromNow } from "../../commons/components/FromNow";
+import { AddProject } from "./AddProject";
+import { useCurrentOrg } from "../../providers/OrgProvider";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { useRoom } from "../../websockets/use-room";
+import { EventType } from "../../websockets/event-type";
+import { Org } from "../orgs/org";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function ProjectList() {
   const { currentOrg } = useCurrentOrg();
@@ -27,11 +28,16 @@ export function ProjectList() {
   const itemsRef = useRef<Project[]>([]);
   const [pagination, setPagination] = useState<PaginationData>();
 
-  useRoom<{ org: Org; project: Project }>('org', currentOrg.org._id, [EventType.project_added], ({ project }) => {
-    if (project.orgId === currentOrg.org._id) {
-      setItems([project, ...items]);
+  useRoom<{ org: Org; project: Project }>(
+    "org",
+    currentOrg.org._id,
+    [EventType.project_added],
+    ({ project }) => {
+      if (project.orgId === currentOrg.org._id) {
+        setItems([project, ...items]);
+      }
     }
-  });
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -43,7 +49,9 @@ export function ProjectList() {
         setItems(itemsRef.current);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list repositories: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list repositories: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [pagination, currentOrg, setLoading]);
 
@@ -55,10 +63,7 @@ export function ProjectList() {
   };
 
   const emptyList = (
-    <EmptyList
-      icon={<ProjectIcon/>}
-      title="No projects"
-    >
+    <EmptyList icon={<ProjectIcon />} title="No projects">
       <AddProject>
         <button type="button" className="btn btn-primary d-block">
           Add project
@@ -68,9 +73,9 @@ export function ProjectList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <div className="mt-5" key={uniqueId()}>
       {items.length === 0 ? (
@@ -79,15 +84,19 @@ export function ProjectList() {
         <>
           <h2>Projects</h2>
           <ul className="list-group">
-            {items.map(project => (
-              <Link to={`/projects/${project._id}`} className="d-block" key={project._id}>
+            {items.map((project) => (
+              <Link
+                to={`/projects/${project._id}`}
+                className="d-block"
+                key={project._id}
+              >
                 <li className="list-group-item list-group-item-action d-flex align-items-center justify-content-between">
                   <div className="d-flex align-items-center">
-                    <Bubble color={project.color} src={project.logo}/>
+                    <Bubble color={project.color} src={project.logo} />
                     <span className="ml-2">{project.name}</span>
                   </div>
                   <div className="d-flex align-items-center">
-                    <FromNow date={project.createdAt} label="Created"/>
+                    <FromNow date={project.createdAt} label="Created" />
                   </div>
                 </li>
               </Link>
@@ -96,11 +105,7 @@ export function ProjectList() {
         </>
       )}
       {pagination && (
-        <LoadMore
-          onClick={nextPage}
-          loading={loading}
-          disabled={loading}
-        />
+        <LoadMore onClick={nextPage} loading={loading} disabled={loading} />
       )}
     </div>
   );

--- a/ui/src/components/projects/members/DeleteMember.tsx
+++ b/ui/src/components/projects/members/DeleteMember.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { IsAdmin } from '../../auth/IsAdmin';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { IsAdmin } from "../../auth/IsAdmin";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function DeleteMember({
-  projectId, memberId, className, children, onDelete,
+  projectId,
+  memberId,
+  className,
+  children,
+  onDelete,
 }: {
   projectId: string;
   memberId: string;
@@ -26,8 +31,8 @@ export function DeleteMember({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete member: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete member: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/projects/members/Members.tsx
+++ b/ui/src/components/projects/members/Members.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { ProjectMember } from './project-member';
-import { axios } from '../../../providers/axios';
-import { AddMember } from './add/AddMember';
-import { MemberView } from './MemberView';
-import styles from './Members.module.scss';
-import { ProjectMemberIcon } from '../../icons/ProjectMemberIcon';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { ProjectMember } from "./project-member";
+import { axios } from "../../../providers/axios";
+import { AddMember } from "./add/AddMember";
+import { MemberView } from "./MemberView";
+import styles from "./Members.module.scss";
+import { ProjectMemberIcon } from "../../icons/ProjectMemberIcon";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function sortMembers(a: ProjectMember, b: ProjectMember): number {
   return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
@@ -26,15 +27,18 @@ export function Members() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get(`/api/v1/projects/${projectId}/members`)
+    axios
+      .get(`/api/v1/projects/${projectId}/members`)
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list members: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list members: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [projectId, setLoading]);
 
-  const onAdd = member => {
+  const onAdd = (member) => {
     setItems([member, ...items].sort(sortMembers));
   };
 
@@ -43,10 +47,7 @@ export function Members() {
   };
 
   const emptyList = (
-    <EmptyList
-      icon={<ProjectMemberIcon/>}
-      title="No members"
-    >
+    <EmptyList icon={<ProjectMemberIcon />} title="No members">
       <p>There are no members yet</p>
       <AddMember projectId={projectId} onAdded={onAdd}>
         <button type="button" className="btn btn-primary">
@@ -57,9 +58,9 @@ export function Members() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       {items.length === 0 ? (
@@ -70,11 +71,11 @@ export function Members() {
             <AddMember
               projectId={projectId}
               onAdded={onAdd}
-              className={classNames('list-group-item', styles.add)}
+              className={classNames("list-group-item", styles.add)}
             >
               Add member
             </AddMember>
-            {items.map(member => (
+            {items.map((member) => (
               <MemberView
                 key={member.memberId}
                 projectId={projectId}

--- a/ui/src/components/projects/members/add/AddMember.tsx
+++ b/ui/src/components/projects/members/add/AddMember.tsx
@@ -1,21 +1,28 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { toast } from 'react-toastify';
-import { getMembers, OrgMembersSearchQuery } from '../../../orgs/staff/members/get-members';
-import { OrgMember } from '../../../orgs/staff/members/org-member';
-import { CardModal } from '../../../../commons/components/modals/CardModal';
-import { SearchInput } from '../../../sites/releases/SearchInput';
-import { LoadMore } from '../../../../commons/components/LoadMore';
-import { Loader } from '../../../../commons/components/Loader';
-import { AlertError } from '../../../../commons/components/AlertError';
-import styles from './AddMember.module.scss';
-import { ListItem } from './ListItem';
-import { useCurrentOrg } from '../../../../providers/OrgProvider';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { IsAdmin } from '../../../auth/IsAdmin';
-import { ProjectMember } from '../project-member';
+import React, { useEffect, useRef, useState } from "react";
+import { toast } from "react-toastify";
+import {
+  getMembers,
+  OrgMembersSearchQuery,
+} from "../../../orgs/staff/members/get-members";
+import { OrgMember } from "../../../orgs/staff/members/org-member";
+import { CardModal } from "../../../../commons/components/modals/CardModal";
+import { SearchInput } from "../../../sites/releases/SearchInput";
+import { LoadMore } from "../../../../commons/components/LoadMore";
+import { Loader } from "../../../../commons/components/Loader";
+import { AlertError } from "../../../../commons/components/AlertError";
+import styles from "./AddMember.module.scss";
+import { ListItem } from "./ListItem";
+import { useCurrentOrg } from "../../../../providers/OrgProvider";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { IsAdmin } from "../../../auth/IsAdmin";
+import { ProjectMember } from "../project-member";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function AddMember({
-  projectId, className, children, onAdded,
+  projectId,
+  className,
+  children,
+  onAdded,
 }: {
   projectId: string;
   children: any;
@@ -28,7 +35,9 @@ export function AddMember({
   const [loading, setLoading] = useMountedState(false);
   const [error, setError] = useState();
   const [query, setQuery] = useState<OrgMembersSearchQuery>({
-    search: '', page: 0, size: 10,
+    search: "",
+    page: 0,
+    size: 10,
   });
   const [items, setItems] = useState<OrgMember[]>([]);
   const itemsRef = useRef<OrgMember[]>([]);
@@ -38,14 +47,14 @@ export function AddMember({
     setError(undefined);
     setLoading(true);
     getMembers(currentOrg.org._id, query)
-      .then(data => {
+      .then((data) => {
         itemsRef.current = [...itemsRef.current, ...data.items];
         setItems(itemsRef.current);
         setCanLoadMore(itemsRef.current.length !== data.count);
       })
       .catch(setError)
-      .catch(err => {
-        toast.error(`Could not search releases: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not search releases: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);
@@ -65,10 +74,12 @@ export function AddMember({
     onAdded(member);
   };
 
-  const onSearch = val => {
+  const onSearch = (val) => {
     itemsRef.current = [];
     setQuery({
-      ...query, search: val, page: 0,
+      ...query,
+      search: val,
+      page: 0,
     });
   };
 
@@ -87,12 +98,12 @@ export function AddMember({
           className="mb-4"
         />
         {initialLoad ? (
-          <Loader/>
+          <Loader />
         ) : error ? (
-          <AlertError error={error}/>
+          <AlertError error={error} />
         ) : (
           <ul className="list-group">
-            {items.map(item => (
+            {items.map((item) => (
               <ListItem
                 key={item._id}
                 member={item}

--- a/ui/src/components/projects/members/add/ListItem.tsx
+++ b/ui/src/components/projects/members/add/ListItem.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { axios } from '../../../../providers/axios';
-import { Loader } from '../../../../commons/components/Loader';
-import { OrgMember } from '../../../orgs/staff/members/org-member';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { ProjectMember } from '../project-member';
+import React from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { axios } from "../../../../providers/axios";
+import { Loader } from "../../../../commons/components/Loader";
+import { OrgMember } from "../../../orgs/staff/members/org-member";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { ProjectMember } from "../project-member";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function ListItem({
-  projectId, member, onAdded,
+  projectId,
+  member,
+  onAdded,
 }: {
   projectId: string;
   member: OrgMember;
@@ -19,14 +22,17 @@ export function ListItem({
   const select = () => {
     setLoading(true);
     return axios
-      .put<ProjectMember>(`/api/v1/projects/${projectId}/members/${member._id}`, {
-        member: member._id,
-      })
+      .put<ProjectMember>(
+        `/api/v1/projects/${projectId}/members/${member._id}`,
+        {
+          member: member._id,
+        }
+      )
       .then(({ data }) => {
         onAdded(data);
       })
-      .catch(err => {
-        toast.error(`Could not select branch: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not select branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -34,16 +40,12 @@ export function ListItem({
   return (
     <div
       className={classNames(
-        'list-group-item list-group-item-action d-flex justify-content-between align-items-center bg-light',
+        "list-group-item list-group-item-action d-flex justify-content-between align-items-center bg-light"
       )}
       onClick={() => select()}
     >
       <strong>{member.name}</strong>
-      <div>
-        {loading && (
-          <Loader/>
-        )}
-      </div>
+      <div>{loading && <Loader />}</div>
     </div>
   );
 }

--- a/ui/src/components/projects/settings/ProjectGeneralSettings.tsx
+++ b/ui/src/components/projects/settings/ProjectGeneralSettings.tsx
@@ -1,15 +1,19 @@
-import { FormProvider, useForm } from 'react-hook-form';
-import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import styles from './ProjectGeneralSettings.module.scss';
-import { Button } from '../../../commons/components/Button';
-import { ProjectNameInput } from './ProjectNameInput';
-import { useProject } from '../ProjectView';
-import { axios } from '../../../providers/axios';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { COLOR_PATTERN, required } from '../../../commons/components/forms/form-constants';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { FormProvider, useForm } from "react-hook-form";
+import React, { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import styles from "./ProjectGeneralSettings.module.scss";
+import { Button } from "../../../commons/components/Button";
+import { ProjectNameInput } from "./ProjectNameInput";
+import { useProject } from "../ProjectView";
+import { axios } from "../../../providers/axios";
+import { InputError } from "../../../commons/components/forms/InputError";
+import {
+  COLOR_PATTERN,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface Settings {
   name: string;
@@ -21,10 +25,14 @@ export function ProjectGeneralSettings() {
   const { project, setProject } = useProject();
 
   const methods = useForm<Settings>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const {
-    errors, register, reset, handleSubmit, formState: { isDirty },
+    errors,
+    register,
+    reset,
+    handleSubmit,
+    formState: { isDirty },
   } = methods;
 
   useEffect(() => {
@@ -41,26 +49,26 @@ export function ProjectGeneralSettings() {
       .put<Settings>(`/api/v1/projects/${projectId}`, settings)
       .then(({ data }) => data)
       .then(setProject)
-      .then(() => toast.success('Project saved'))
-      .catch(err => toast.error(`Could not update project: ${err}`))
+      .then(() => toast.success("Project saved"))
+      .catch((err) =>
+        toast.error(`Could not update project: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   };
 
   return (
     <FormProvider {...methods}>
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className={styles.form}
-      >
-
+      <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <div className="mt-4 card">
           <div className="card-header">
             <strong>Project</strong>
           </div>
           <div className="card-body">
-            <ProjectNameInput/>
+            <ProjectNameInput />
             <div className="form-group">
-              <label htmlFor="color" className="form-label">Color</label>
+              <label htmlFor="color" className="form-label">
+                Color
+              </label>
               <input
                 type="color"
                 id="color"
@@ -74,7 +82,7 @@ export function ProjectGeneralSettings() {
                 autoComplete="off"
                 defaultValue="#000000"
               />
-              <InputError error={errors} path="color"/>
+              <InputError error={errors} path="color" />
             </div>
           </div>
         </div>
@@ -99,7 +107,6 @@ export function ProjectGeneralSettings() {
             Save
           </Button>
         </div>
-
       </form>
     </FormProvider>
   );

--- a/ui/src/components/sidebar/Projects.tsx
+++ b/ui/src/components/sidebar/Projects.tsx
@@ -1,32 +1,46 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { NavLink } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { faPlus } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Loader } from '../../commons/components/Loader';
-import { AlertError } from '../../commons/components/AlertError';
-import { Project } from '../projects/project';
-import styles from './Projects.module.scss';
-import { Bubble } from '../../commons/components/Bubble';
-import { axios } from '../../providers/axios';
-import { AddSite } from '../sites/AddSite';
-import { ButtonIcon } from '../../commons/components/ButtonIcon';
-import { Sites } from './Sites';
-import { useCurrentOrg } from '../../providers/OrgProvider';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { useRoom } from '../../websockets/use-room';
-import { EventType } from '../../websockets/event-type';
+import React, { useEffect, useRef, useState } from "react";
+import { NavLink } from "react-router-dom";
+import { toast } from "react-toastify";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Loader } from "../../commons/components/Loader";
+import { AlertError } from "../../commons/components/AlertError";
+import { Project } from "../projects/project";
+import styles from "./Projects.module.scss";
+import { Bubble } from "../../commons/components/Bubble";
+import { axios } from "../../providers/axios";
+import { AddSite } from "../sites/AddSite";
+import { ButtonIcon } from "../../commons/components/ButtonIcon";
+import { Sites } from "./Sites";
+import { useCurrentOrg } from "../../providers/OrgProvider";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { useRoom } from "../../websockets/use-room";
+import { EventType } from "../../websockets/event-type";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 function sortProjects(a: Project, b: Project) {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
 }
 
-function ProjectSection({ project, className, onDelete }: { project: Project; className?; onDelete: () => void }) {
-  useRoom<{ project: Project }>('project', project._id, [EventType.project_deleted], ({ project: deletedProject }) => {
-    if (project._id === deletedProject._id) {
-      onDelete();
+function ProjectSection({
+  project,
+  className,
+  onDelete,
+}: {
+  project: Project;
+  className?;
+  onDelete: () => void;
+}) {
+  useRoom<{ project: Project }>(
+    "project",
+    project._id,
+    [EventType.project_deleted],
+    ({ project: deletedProject }) => {
+      if (project._id === deletedProject._id) {
+        onDelete();
+      }
     }
-  });
+  );
 
   return (
     <div className={className}>
@@ -36,18 +50,18 @@ function ProjectSection({ project, className, onDelete }: { project: Project; cl
           to={`/projects/${project._id}`}
           activeClassName={styles.active}
         >
-          <Bubble color={project.color} src={project.logo}/>
+          <Bubble color={project.color} src={project.logo} />
           <span className="ml-2 text-uppercase">{project.name}</span>
         </NavLink>
         <div>
           <AddSite projectId={project._id}>
             <ButtonIcon>
-              <FontAwesomeIcon icon={faPlus}/>
+              <FontAwesomeIcon icon={faPlus} />
             </ButtonIcon>
           </AddSite>
         </div>
       </div>
-      <Sites projectId={project._id}/>
+      <Sites projectId={project._id} />
     </div>
   );
 }
@@ -59,11 +73,16 @@ export function Projects({ className }: { className? }) {
   const projectsRef = useRef<Project[]>([]);
   const { currentOrg } = useCurrentOrg();
 
-  useRoom<{ project: Project }>('org', currentOrg.org._id, [EventType.project_added], ({ project }) => {
-    if (project.orgId === currentOrg.org._id) {
-      setProjects([project, ...projects]);
+  useRoom<{ project: Project }>(
+    "org",
+    currentOrg.org._id,
+    [EventType.project_added],
+    ({ project }) => {
+      if (project.orgId === currentOrg.org._id) {
+        setProjects([project, ...projects]);
+      }
     }
-  });
+  );
 
   useEffect(() => {
     setLoading(true);
@@ -75,7 +94,9 @@ export function Projects({ className }: { className? }) {
         setProjects(projectsRef.current.sort(sortProjects));
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list projects: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list projects: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [currentOrg, setLoading]);
 
@@ -84,18 +105,16 @@ export function Projects({ className }: { className? }) {
   };
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <div className={className}>
       {projects.length === 0 ? (
-        <>
-          No projects to show
-        </>
+        <>No projects to show</>
       ) : (
         <>
-          {projects.map(project => (
+          {projects.map((project) => (
             <ProjectSection
               project={project}
               key={project._id}

--- a/ui/src/components/sites/AddSite.tsx
+++ b/ui/src/components/sites/AddSite.tsx
@@ -1,37 +1,42 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { uniqueId } from 'lodash';
-import { FormProvider, useForm } from 'react-hook-form';
-import { axios } from '../../providers/axios';
-import { routerHistory } from '../../providers/history';
-import { Tooltip, tooltipToggle } from '../../commons/components/Tooltip';
-import { SiteNameInput } from './settings/SiteNameInput';
-import { Button } from '../../commons/components/Button';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { Site } from './site';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { IsAdmin } from '../auth/IsAdmin';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { uniqueId } from "lodash";
+import { FormProvider, useForm } from "react-hook-form";
+import { axios } from "../../providers/axios";
+import { routerHistory } from "../../providers/history";
+import { Tooltip, tooltipToggle } from "../../commons/components/Tooltip";
+import { SiteNameInput } from "./settings/SiteNameInput";
+import { Button } from "../../commons/components/Button";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { Site } from "./site";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { IsAdmin } from "../auth/IsAdmin";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 function AddSiteModal({ projectId, closeModal }: { projectId; closeModal }) {
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
-  const onChange = formData => axios
-    .post<Site>(`/api/v1/projects/${projectId}/sites`, formData)
-    .then(({ data }) => {
-      routerHistory.push(`/sites/${data._id}`);
-    })
-    .finally(() => {
-      closeModal();
-    })
-    .catch(err => {
-      toast.error(`Could not create site: ${err}`);
-    });
+  const onChange = (formData) =>
+    axios
+      .post<Site>(`/api/v1/projects/${projectId}/sites`, formData)
+      .then(({ data }) => {
+        routerHistory.push(`/sites/${data._id}`);
+      })
+      .finally(() => {
+        closeModal();
+      })
+      .catch((err) => {
+        toast.error(`Could not create site: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -47,7 +52,7 @@ function AddSiteModal({ projectId, closeModal }: { projectId; closeModal }) {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <SiteNameInput setInputRef={setInputRef}/>
+        <SiteNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -64,7 +69,10 @@ function AddSiteModal({ projectId, closeModal }: { projectId; closeModal }) {
 }
 
 export function AddSite({
-  projectId, children, className, tooltip = true,
+  projectId,
+  children,
+  className,
+  tooltip = true,
 }: {
   projectId: string;
   children;
@@ -79,11 +87,7 @@ export function AddSite({
   return (
     <>
       <IsAdmin>
-        <div
-          onClick={openModal}
-          className={className}
-          {...tooltipToggle(uid)}
-        >
+        <div onClick={openModal} className={className} {...tooltipToggle(uid)}>
           {children}
         </div>
       </IsAdmin>
@@ -93,7 +97,7 @@ export function AddSite({
         </Tooltip>
       )}
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Add site">
-        <AddSiteModal closeModal={closeModal} projectId={projectId}/>
+        <AddSiteModal closeModal={closeModal} projectId={projectId} />
       </CardModal>
     </>
   );

--- a/ui/src/components/sites/DeleteSite.tsx
+++ b/ui/src/components/sites/DeleteSite.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { axios } from '../../providers/axios';
-import { routerHistory } from '../../providers/history';
-import { Button } from '../../commons/components/Button';
-import { CardModal } from '../../commons/components/modals/CardModal';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { axios } from "../../providers/axios";
+import { routerHistory } from "../../providers/history";
+import { Button } from "../../commons/components/Button";
+import { CardModal } from "../../commons/components/modals/CardModal";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function DeleteSite({
-  id, projectId, className, children,
+  id,
+  projectId,
+  className,
+  children,
 }: {
   id: string;
   projectId: string;
@@ -25,8 +29,8 @@ export function DeleteSite({
         setIsOpen(false);
         routerHistory.push(`/projects/${projectId}/sites`);
       })
-      .catch(err => {
-        toast.error(`Could not delete site: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete site: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/SiteList.tsx
+++ b/ui/src/components/sites/SiteList.tsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { uniqueId } from 'lodash';
-import { Loader } from '../../commons/components/Loader';
-import { EmptyList } from '../../commons/components/EmptyList';
-import { getProjectSites } from './get-project-sites';
-import { SiteCard } from './SiteCard';
-import { AlertError } from '../../commons/components/AlertError';
-import { Site } from './site';
-import { AddSite } from './AddSite';
-import { SiteIcon } from '../icons/SiteIcon';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { uniqueId } from "lodash";
+import { Loader } from "../../commons/components/Loader";
+import { EmptyList } from "../../commons/components/EmptyList";
+import { getProjectSites } from "./get-project-sites";
+import { SiteCard } from "./SiteCard";
+import { AlertError } from "../../commons/components/AlertError";
+import { Site } from "./site";
+import { AddSite } from "./AddSite";
+import { SiteIcon } from "../icons/SiteIcon";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 export function SiteList() {
   const { projectId } = useParams<any>();
@@ -23,20 +24,19 @@ export function SiteList() {
     setLoading(true);
     setError(undefined);
     getProjectSites(projectId)
-      .then(data => {
+      .then((data) => {
         itemsRef.current.push(...data);
         setItems(itemsRef.current);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list repos: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list repos: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [projectId, setLoading]);
 
   const emptyList = (
-    <EmptyList
-      icon={<SiteIcon/>}
-      title="No sites"
-    >
+    <EmptyList icon={<SiteIcon />} title="No sites">
       <AddSite projectId={projectId}>
         <button type="button" className="btn btn-primary d-block">
           Add site
@@ -46,9 +46,9 @@ export function SiteList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <div className="mt-5" key={uniqueId()}>
       {items.length === 0 ? (
@@ -56,9 +56,9 @@ export function SiteList() {
       ) : (
         <>
           <h2>Sites</h2>
-          {items.map(site => (
+          {items.map((site) => (
             <Link to={`/sites/${site._id}`} className="d-block" key={site._id}>
-              <SiteCard site={site}/>
+              <SiteCard site={site} />
             </Link>
           ))}
         </>

--- a/ui/src/components/sites/branches/AddBranch.tsx
+++ b/ui/src/components/sites/branches/AddBranch.tsx
@@ -1,38 +1,45 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { FormProvider, useForm } from 'react-hook-form';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Branch } from './branch';
-import { BranchNameInput } from './BranchNameInput';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { FormProvider, useForm } from "react-hook-form";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Branch } from "./branch";
+import { BranchNameInput } from "./BranchNameInput";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function ModalContent({
-  siteId, releaseId, onAdded,
+  siteId,
+  releaseId,
+  onAdded,
 }: {
   siteId: string;
   releaseId?: string;
   onAdded: (branch: Branch) => void;
 }) {
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
-  const onChange = formData => axios
-    .post<Branch>(`/api/v1/sites/${siteId}/branches`, {
-      ...formData,
-      releaseId,
-    })
-    .then(({ data }) => data)
-    .then(onAdded)
-    .catch(err => {
-      toast.error(`Could not create branch: ${err}`);
-    });
+  const onChange = (formData) =>
+    axios
+      .post<Branch>(`/api/v1/sites/${siteId}/branches`, {
+        ...formData,
+        releaseId,
+      })
+      .then(({ data }) => data)
+      .then(onAdded)
+      .catch((err) => {
+        toast.error(`Could not create branch: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -48,7 +55,7 @@ function ModalContent({
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <BranchNameInput setInputRef={setInputRef}/>
+        <BranchNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -65,7 +72,11 @@ function ModalContent({
 }
 
 export function AddBranch({
-  children, className, siteId, releaseId, onAdded,
+  children,
+  className,
+  siteId,
+  releaseId,
+  onAdded,
 }: {
   children;
   className?;
@@ -77,21 +88,18 @@ export function AddBranch({
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
-  const added = val => {
+  const added = (val) => {
     onAdded(val);
     closeModal();
   };
 
   return (
     <>
-      <div
-        onClick={openModal}
-        className={className}
-      >
+      <div onClick={openModal} className={className}>
         {children}
       </div>
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Add branch">
-        <ModalContent onAdded={added} siteId={siteId} releaseId={releaseId}/>
+        <ModalContent onAdded={added} siteId={siteId} releaseId={releaseId} />
       </CardModal>
     </>
   );

--- a/ui/src/components/sites/branches/BranchList.tsx
+++ b/ui/src/components/sites/branches/BranchList.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { axios } from '../../../providers/axios';
-import styles from './BranchList.module.scss';
-import { BranchIcon } from '../../icons/BranchIcon';
-import { AddBranch } from './AddBranch';
-import { Branch } from './branch';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { BranchListItemView } from './BranchListItem';
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { axios } from "../../../providers/axios";
+import styles from "./BranchList.module.scss";
+import { BranchIcon } from "../../icons/BranchIcon";
+import { AddBranch } from "./AddBranch";
+import { Branch } from "./branch";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { BranchListItemView } from "./BranchListItem";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function sortBranches(a: Branch, b: Branch): number {
   return new Date(b.name).getTime() - new Date(a.name).getTime();
@@ -26,22 +27,22 @@ export function BranchList() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get<Branch[]>(`/api/v1/sites/${siteId}/branches`)
+    axios
+      .get<Branch[]>(`/api/v1/sites/${siteId}/branches`)
       .then(({ data }) => setItems(data))
       .catch(setError)
-      .catch(err => toast.error(`Could not list branches: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list branches: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [siteId, setLoading]);
 
-  const onAdded = branch => {
+  const onAdded = (branch) => {
     setItems([branch, ...items].sort(sortBranches));
   };
 
   const emptyList = (
-    <EmptyList
-      icon={<BranchIcon/>}
-      title="No branches"
-    >
+    <EmptyList icon={<BranchIcon />} title="No branches">
       <p>There are no branches yet</p>
       <AddBranch siteId={siteId} onAdded={onAdded}>
         <button type="button" className="btn btn-primary">
@@ -52,9 +53,9 @@ export function BranchList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       {items.length === 0 ? (
@@ -64,15 +65,15 @@ export function BranchList() {
           <AddBranch
             siteId={siteId}
             onAdded={onAdded}
-            className={classNames('list-group-item list-group-item-action', styles.add)}
+            className={classNames(
+              "list-group-item list-group-item-action",
+              styles.add
+            )}
           >
             Add branch
           </AddBranch>
-          {items.map(branch => (
-            <BranchListItemView
-              key={branch._id}
-              branch={branch}
-            />
+          {items.map((branch) => (
+            <BranchListItemView key={branch._id} branch={branch} />
           ))}
         </div>
       )}

--- a/ui/src/components/sites/branches/BranchNameInput.tsx
+++ b/ui/src/components/sites/branches/BranchNameInput.tsx
@@ -1,47 +1,66 @@
-import { useFormContext } from 'react-hook-form';
-import React from 'react';
-import { toast } from 'react-toastify';
-import { maxLength, required } from '../../../commons/components/forms/form-constants';
-import { debounceTime } from '../../../utils/debounce-time';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { axios } from '../../../providers/axios';
-import { useSite } from '../SiteView';
+import { useFormContext } from "react-hook-form";
+import React from "react";
+import { toast } from "react-toastify";
+import {
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { debounceTime } from "../../../utils/debounce-time";
+import { InputError } from "../../../commons/components/forms/InputError";
+import { axios } from "../../../providers/axios";
+import { useSite } from "../SiteView";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
-async function validateName(siteId: string, name: string): Promise<string | undefined> {
+async function validateName(
+  siteId: string,
+  name: string
+): Promise<string | undefined> {
   if (!name) {
     return undefined;
   }
   return axios
-    .post<string | undefined>(`/api/v1/sites/${siteId}/branches.validate/name`, {
-      name,
-    })
+    .post<string | undefined>(
+      `/api/v1/sites/${siteId}/branches.validate/name`,
+      {
+        name,
+      }
+    )
     .then(({ data }) => data || undefined)
-    .catch(err => {
-      toast.error(`Could not validate branch name: ${err}`);
+    .catch((err) => {
+      toast.error(
+        `Could not validate branch name: ${extractErrorMessage(err)}`
+      );
       return undefined;
     });
 }
 
-export function BranchNameInput({ setInputRef }: {
+export function BranchNameInput({
+  setInputRef,
+}: {
   setInputRef?: (input: HTMLInputElement) => void;
 }) {
   const { register, errors } = useFormContext();
   const { site } = useSite();
 
-  const ref = input => {
+  const ref = (input) => {
     if (setInputRef) {
       setInputRef(input);
     }
     register({
       required,
       maxLength: maxLength(),
-      validate: debounceTime<string | undefined>(val => validateName(site._id, val), 300),
+      validate: debounceTime<string | undefined>(
+        (val) => validateName(site._id, val),
+        300
+      ),
     })(input);
   };
 
   return (
     <div className="form-group">
-      <label htmlFor="name" className="form-label">Name</label>
+      <label htmlFor="name" className="form-label">
+        Name
+      </label>
       <input
         type="text"
         id="name"
@@ -51,7 +70,7 @@ export function BranchNameInput({ setInputRef }: {
         placeholder="next"
         autoComplete="off"
       />
-      <InputError error={errors} path="name"/>
+      <InputError error={errors} path="name" />
     </div>
   );
 }

--- a/ui/src/components/sites/branches/BranchPassword.tsx
+++ b/ui/src/components/sites/branches/BranchPassword.tsx
@@ -1,22 +1,29 @@
-import React, { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Toggle } from '../../../commons/components/forms/Toggle';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Branch } from './branch';
-import { Button } from '../../../commons/components/Button';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { maxLength, required } from '../../../commons/components/forms/form-constants';
-import { axios } from '../../../providers/axios';
-import { randomString } from '../../../commons/utils/random-string';
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Toggle } from "../../../commons/components/forms/Toggle";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Branch } from "./branch";
+import { Button } from "../../../commons/components/Button";
+import { InputError } from "../../../commons/components/forms/InputError";
+import {
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { axios } from "../../../providers/axios";
+import { randomString } from "../../../commons/utils/random-string";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface FormData {
   password: string;
 }
 
 export function BranchPassword({
-  siteId, branch, onChange, className,
+  siteId,
+  branch,
+  onChange,
+  className,
 }: {
   siteId: string;
   branch: Branch;
@@ -33,10 +40,8 @@ export function BranchPassword({
     setRandomSecret(randomString(16));
   }, [isOpen]);
 
-  const {
-    register, errors, handleSubmit,
-  } = useForm<FormData>({
-    mode: 'onChange',
+  const { register, errors, handleSubmit } = useForm<FormData>({
+    mode: "onChange",
   });
 
   const [loading, setLoading] = useState(false);
@@ -44,13 +49,18 @@ export function BranchPassword({
   const setPassword = (formData: FormData) => {
     setLoading(true);
     axios
-      .put<Branch>(`/api/v1/sites/${siteId}/branches/${branch._id}/password`, formData)
+      .put<Branch>(
+        `/api/v1/sites/${siteId}/branches/${branch._id}/password`,
+        formData
+      )
       .then(({ data }) => {
         onChange(data);
         closeModal();
       })
-      .catch(err => {
-        toast.error(`Could not set branch password: ${err}`);
+      .catch((err) => {
+        toast.error(
+          `Could not set branch password: ${extractErrorMessage(err)}`
+        );
       })
       .finally(() => setLoading(false));
   };
@@ -60,8 +70,10 @@ export function BranchPassword({
     axios
       .delete<Branch>(`/api/v1/sites/${siteId}/branches/${branch._id}/password`)
       .then(({ data }) => onChange(data))
-      .catch(err => {
-        toast.error(`Could not remove branch password: ${err}`);
+      .catch((err) => {
+        toast.error(
+          `Could not remove branch password: ${extractErrorMessage(err)}`
+        );
       })
       .finally(() => setLoading(false));
   };
@@ -72,24 +84,26 @@ export function BranchPassword({
         value={!!branch.hasPassword}
         onChange={() => (branch.hasPassword ? removePassword() : openModal())}
         loading={branch.hasPassword && loading}
-        className={classNames(className, 'w-100 font-weight-bold')}
+        className={classNames(className, "w-100 font-weight-bold")}
       >
-        Password protection
-        {' '}
+        Password protection{" "}
         {branch.hasPassword && (
           <>
-            {' '}
-            (user name is
-            {' '}
-            <code>user</code>
-            )
+            {" "}
+            (user name is <code>user</code>)
           </>
         )}
       </Toggle>
-      <CardModal isOpen={isOpen} closeModal={closeModal} title="Set branch password">
+      <CardModal
+        isOpen={isOpen}
+        closeModal={closeModal}
+        title="Set branch password"
+      >
         <form onSubmit={handleSubmit(setPassword)}>
           <div className="form-group">
-            <label htmlFor="password" className="form-label">Password</label>
+            <label htmlFor="password" className="form-label">
+              Password
+            </label>
             <input
               type="text"
               id="password"
@@ -103,7 +117,7 @@ export function BranchPassword({
               autoComplete="off"
               defaultValue={randomSecret}
             />
-            <InputError error={errors} path="password"/>
+            <InputError error={errors} path="password" />
           </div>
           <div className="d-flex justify-content-end">
             <Button

--- a/ui/src/components/sites/branches/DeleteBranch.tsx
+++ b/ui/src/components/sites/branches/DeleteBranch.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function DeleteBranch({
-  siteId, branchId, className, children, onDelete,
+  siteId,
+  branchId,
+  className,
+  children,
+  onDelete,
 }: {
   siteId: string;
   branchId: string;
@@ -25,8 +30,8 @@ export function DeleteBranch({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete branch: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/RenameBranch.tsx
+++ b/ui/src/components/sites/branches/RenameBranch.tsx
@@ -1,33 +1,42 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { FormProvider, useForm } from 'react-hook-form';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Branch } from './branch';
-import { BranchNameInput } from './BranchNameInput';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { FormProvider, useForm } from "react-hook-form";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Branch } from "./branch";
+import { BranchNameInput } from "./BranchNameInput";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function ModalContent({
-  siteId, branchId, onRenamed,
+  siteId,
+  branchId,
+  onRenamed,
 }: {
   siteId: string;
   branchId: string;
   onRenamed: (branch: Branch) => void;
 }) {
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
-  const onSubmit = formData => {
+  const onSubmit = (formData) => {
     setLoading(true);
     axios
-      .put<Branch>(`/api/v1/sites/${siteId}/branches/${branchId}/name`, formData)
+      .put<Branch>(
+        `/api/v1/sites/${siteId}/branches/${branchId}/name`,
+        formData
+      )
       .then(({ data }) => onRenamed(data))
-      .catch(err => {
-        toast.error(`Could not rename branch: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not rename branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -43,7 +52,7 @@ function ModalContent({
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <BranchNameInput setInputRef={setInputRef}/>
+        <BranchNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -60,7 +69,11 @@ function ModalContent({
 }
 
 export function RenameBranch({
-  children, className, siteId, branchId, onRenamed,
+  children,
+  className,
+  siteId,
+  branchId,
+  onRenamed,
 }: {
   children;
   className?;
@@ -72,21 +85,18 @@ export function RenameBranch({
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
-  const renamed = val => {
+  const renamed = (val) => {
     onRenamed(val);
     closeModal();
   };
 
   return (
     <>
-      <div
-        onClick={openModal}
-        className={className}
-      >
+      <div onClick={openModal} className={className}>
         {children}
       </div>
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Rename branch">
-        <ModalContent onRenamed={renamed} siteId={siteId} branchId={branchId}/>
+        <ModalContent onRenamed={renamed} siteId={siteId} branchId={branchId} />
       </CardModal>
     </>
   );

--- a/ui/src/components/sites/branches/forms/Forms.tsx
+++ b/ui/src/components/sites/branches/forms/Forms.tsx
@@ -1,18 +1,16 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { useParams } from 'react-router-dom';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../../providers/axios';
-import { Loader } from '../../../../commons/components/Loader';
-import { AlertError } from '../../../../commons/components/AlertError';
-import { Branch } from '../branch';
-import { FormList } from './FormList';
-import { Form, Release } from '../../releases/release';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { useParams } from "react-router-dom";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../../providers/axios";
+import { Loader } from "../../../../commons/components/Loader";
+import { AlertError } from "../../../../commons/components/AlertError";
+import { Branch } from "../branch";
+import { FormList } from "./FormList";
+import { Form, Release } from "../../releases/release";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
-function useBranchForms(
-  siteId: string,
-  branchId: string,
-) {
+function useBranchForms(siteId: string, branchId: string) {
   const [loading, setLoading] = useMountedState(true);
   const [error, setError] = useState();
   const [forms, setForms] = useState<Form[]>();
@@ -22,9 +20,9 @@ function useBranchForms(
     setError(undefined);
     axios
       .get<Branch>(`/api/v1/sites/${siteId}/branches/${branchId}`)
-      .then(({ data }) => (
+      .then(({ data }) =>
         axios.get<Release>(`/api/v1/releases/${data.release}`)
-      ))
+      )
       .then(({ data }) => data.forms)
       .then(setForms)
       .catch(setError)
@@ -42,7 +40,7 @@ function useBranchForms(
 function useSetBranchForms(
   siteId: string,
   branchId: string,
-  setForms: (forms: Form[]) => void,
+  setForms: (forms: Form[]) => void
 ) {
   const [loading, setLoading] = useMountedState(false);
 
@@ -50,17 +48,17 @@ function useSetBranchForms(
     setLoading(true);
     axios
       .get<Branch>(`/api/v1/sites/${siteId}/branches/${branchId}`)
-      .then(({ data }) => (
+      .then(({ data }) =>
         axios.put<Form[]>(`/api/v1/releases/${data.release}/forms`, {
           forms: forms || [],
         })
-      ))
+      )
       .then(({ data }) => {
         setForms(data);
-        toast.success('Saved forms');
+        toast.success("Saved forms");
       })
-      .catch(err => {
-        toast.error(`Could not save forms: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not save forms: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);
@@ -76,17 +74,17 @@ function useSetBranchForms(
 export function Forms() {
   const { siteId, branchId } = useParams<any>();
   const { forms, setForms, loading, error } = useBranchForms(siteId, branchId);
-  const { loading: updating, updateForms } = useSetBranchForms(siteId, branchId, setForms);
+  const { loading: updating, updateForms } = useSetBranchForms(
+    siteId,
+    branchId,
+    setForms
+  );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
-    <FormList
-      forms={forms}
-      onSubmit={updateForms}
-      submitting={updating}
-    />
+    <FormList forms={forms} onSubmit={updateForms} submitting={updating} />
   );
 }

--- a/ui/src/components/sites/branches/headers/BranchHeaders.tsx
+++ b/ui/src/components/sites/branches/headers/BranchHeaders.tsx
@@ -1,21 +1,19 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { Link, useParams } from 'react-router-dom';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPen } from '@fortawesome/free-solid-svg-icons';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../../providers/axios';
-import { Loader } from '../../../../commons/components/Loader';
-import { AlertError } from '../../../../commons/components/AlertError';
-import { Branch } from '../branch';
-import { Header } from '../header';
-import { HeaderList } from '../../headers/HeaderList';
-import { useSiteHeaders } from '../../headers/use-site-headers';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { Link, useParams } from "react-router-dom";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPen } from "@fortawesome/free-solid-svg-icons";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../../providers/axios";
+import { Loader } from "../../../../commons/components/Loader";
+import { AlertError } from "../../../../commons/components/AlertError";
+import { Branch } from "../branch";
+import { Header } from "../header";
+import { HeaderList } from "../../headers/HeaderList";
+import { useSiteHeaders } from "../../headers/use-site-headers";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
-function useBranchHeaders(
-  siteId: string,
-  branchId: string,
-) {
+function useBranchHeaders(siteId: string, branchId: string) {
   const [loading, setLoading] = useMountedState(true);
   const [error, setError] = useState();
   const [headers, setHeaders] = useState<Header[]>();
@@ -42,7 +40,7 @@ function useBranchHeaders(
 function useSetBranchHeaders(
   siteId: string,
   branchId: string,
-  setHeaders: (headers: Header[]) => void,
+  setHeaders: (headers: Header[]) => void
 ) {
   const [loading, setLoading] = useMountedState(false);
 
@@ -54,10 +52,10 @@ function useSetBranchHeaders(
       })
       .then(({ data }) => {
         setHeaders(data.headers);
-        toast.success('Saved branch headers');
+        toast.success("Saved branch headers");
       })
-      .catch(err => {
-        toast.error(`Could not save headers: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not save headers: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);
@@ -70,39 +68,35 @@ function useSetBranchHeaders(
   };
 }
 
-function SiteHeaders({ siteId }: {
-  siteId: string;
-}) {
+function SiteHeaders({ siteId }: { siteId: string }) {
   const { headers, loading, error } = useSiteHeaders(siteId);
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       <div className="d-flex justify-content-between mb-3 d-flex align-items-center">
         <h2 className="mb-0">Headers set at site level</h2>
         <Link to={`/sites/${siteId}/settings/headers`}>
-          Edit
-          {' '}
-          <FontAwesomeIcon icon={faPen} className="ml-2"/>
+          Edit <FontAwesomeIcon icon={faPen} className="ml-2" />
         </Link>
       </div>
       <table className="table">
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Value</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Value</th>
+          </tr>
         </thead>
         <tbody>
-        {headers.map(({ name, value }) => (
-          <tr key={name}>
-            <td>{name}</td>
-            <td>{value}</td>
-          </tr>
-        ))}
+          {headers.map(({ name, value }) => (
+            <tr key={name}>
+              <td>{name}</td>
+              <td>{value}</td>
+            </tr>
+          ))}
         </tbody>
       </table>
     </>
@@ -111,13 +105,20 @@ function SiteHeaders({ siteId }: {
 
 export function BranchHeaders() {
   const { siteId, branchId } = useParams<any>();
-  const { headers, setHeaders, loading, error } = useBranchHeaders(siteId, branchId);
-  const { loading: updating, updateHeaders } = useSetBranchHeaders(siteId, branchId, setHeaders);
+  const { headers, setHeaders, loading, error } = useBranchHeaders(
+    siteId,
+    branchId
+  );
+  const { loading: updating, updateHeaders } = useSetBranchHeaders(
+    siteId,
+    branchId,
+    setHeaders
+  );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       <h2>Branch headers</h2>
@@ -126,9 +127,7 @@ export function BranchHeaders() {
         onSubmit={updateHeaders}
         submitting={updating}
       />
-      <SiteHeaders
-        siteId={siteId}
-      />
+      <SiteHeaders siteId={siteId} />
     </>
   );
 }

--- a/ui/src/components/sites/branches/redirects/BranchRedirects.tsx
+++ b/ui/src/components/sites/branches/redirects/BranchRedirects.tsx
@@ -1,20 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
-import { useParams } from 'react-router-dom';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../../providers/axios';
-import { Loader } from '../../../../commons/components/Loader';
-import { AlertError } from '../../../../commons/components/AlertError';
-import { Button } from '../../../../commons/components/Button';
-import { BranchRedirectsFormData } from './branch-redirects-form-data';
-import { BranchRedirectForm } from './BranchRedirectForm';
-import { BranchRedirect, RedirectType } from '../branch-redirect';
+import React, { useEffect, useState } from "react";
+import { FormProvider, useFieldArray, useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+import { useParams } from "react-router-dom";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../../providers/axios";
+import { Loader } from "../../../../commons/components/Loader";
+import { AlertError } from "../../../../commons/components/AlertError";
+import { Button } from "../../../../commons/components/Button";
+import { BranchRedirectsFormData } from "./branch-redirects-form-data";
+import { BranchRedirectForm } from "./BranchRedirectForm";
+import { BranchRedirect, RedirectType } from "../branch-redirect";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
-function useBranchFiles(
-  siteId: string,
-  branchId: string,
-) {
+function useBranchFiles(siteId: string, branchId: string) {
   const [loading, setLoading] = useMountedState(false);
   const [error, setError] = useState();
   const [redirects, setFiles] = useState<BranchRedirect[]>();
@@ -23,7 +21,9 @@ function useBranchFiles(
     setLoading(true);
     setError(undefined);
     axios
-      .get<BranchRedirect[]>(`/api/v1/sites/${siteId}/branches/${branchId}/redirects`)
+      .get<BranchRedirect[]>(
+        `/api/v1/sites/${siteId}/branches/${branchId}/redirects`
+      )
       .then(({ data }) => data)
       .then(setFiles)
       .catch(setError)
@@ -41,22 +41,27 @@ function useBranchFiles(
 function useSetFiles(
   siteId: string,
   branchId: string,
-  setFiles: (redirects: BranchRedirect[]) => void,
+  setFiles: (redirects: BranchRedirect[]) => void
 ) {
   const [loading, setLoading] = useMountedState(false);
 
   const updateFiles = (formData: BranchRedirectsFormData) => {
     setLoading(true);
     axios
-      .put<BranchRedirect[]>(`/api/v1/sites/${siteId}/branches/${branchId}/redirects`, {
-        redirects: formData.redirects || [],
-      })
+      .put<BranchRedirect[]>(
+        `/api/v1/sites/${siteId}/branches/${branchId}/redirects`,
+        {
+          redirects: formData.redirects || [],
+        }
+      )
       .then(({ data }) => {
         setFiles(data);
-        toast.success('Saved branch redirects');
+        toast.success("Saved branch redirects");
       })
-      .catch(err => {
-        toast.error(`Could not save branch redirects: ${err}`);
+      .catch((err) => {
+        toast.error(
+          `Could not save branch redirects: ${extractErrorMessage(err)}`
+        );
       })
       .finally(() => setLoading(false));
   };
@@ -70,20 +75,28 @@ function useSetFiles(
 export function BranchRedirects() {
   const { siteId, branchId } = useParams<any>();
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const {
-    control, handleSubmit, formState: { isDirty }, reset,
+    control,
+    handleSubmit,
+    formState: { isDirty },
+    reset,
   } = methods;
   const formFiles = useFieldArray<BranchRedirect>({
     control,
-    name: 'redirects',
+    name: "redirects",
   });
 
-  const {
-    redirects, setFiles, loading, error,
-  } = useBranchFiles(siteId, branchId);
-  const { loading: updating, updateFiles } = useSetFiles(siteId, branchId, setFiles);
+  const { redirects, setFiles, loading, error } = useBranchFiles(
+    siteId,
+    branchId
+  );
+  const { loading: updating, updateFiles } = useSetFiles(
+    siteId,
+    branchId,
+    setFiles
+  );
 
   useEffect(() => {
     if (redirects && reset) {
@@ -94,13 +107,12 @@ export function BranchRedirects() {
   }, [redirects, reset]);
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(updateFiles)}>
-
         {formFiles.fields.map((branchFile, index) => (
           <BranchRedirectForm
             key={branchFile.path || branchFile.id}
@@ -111,9 +123,11 @@ export function BranchRedirects() {
           />
         ))}
         <button
-          onClick={() => formFiles.append({
-            type: RedirectType.file,
-          })}
+          onClick={() =>
+            formFiles.append({
+              type: RedirectType.file,
+            })
+          }
           type="button"
           className="list-group-item list-group-item-action text-center"
         >
@@ -125,9 +139,11 @@ export function BranchRedirects() {
             <Button
               type="button"
               className="mt-3 btn btn-outline-primary animate fadeIn"
-              onClick={() => reset({
-                redirects,
-              })}
+              onClick={() =>
+                reset({
+                  redirects,
+                })
+              }
               disabled={updating}
             >
               Discard

--- a/ui/src/components/sites/branches/release/SetBranchRelease.tsx
+++ b/ui/src/components/sites/branches/release/SetBranchRelease.tsx
@@ -1,13 +1,21 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../../commons/components/Button';
-import { axios } from '../../../../providers/axios';
-import { CardModal } from '../../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
-import { Branch } from '../branch';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../../commons/components/Button";
+import { axios } from "../../../../providers/axios";
+import { CardModal } from "../../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { Branch } from "../branch";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 export function SetBranchRelease({
-  siteId, branchId, releaseId, className, children, onSet, branchName, releaseName,
+  siteId,
+  branchId,
+  releaseId,
+  className,
+  children,
+  onSet,
+  branchName,
+  releaseName,
 }: {
   siteId: string;
   branchId: string;
@@ -31,8 +39,10 @@ export function SetBranchRelease({
         setIsOpen(false);
         onSet();
       })
-      .catch(err => {
-        toast.error(`Could not set branch release: ${err}`);
+      .catch((err) => {
+        toast.error(
+          `Could not set branch release: ${extractErrorMessage(err)}`
+        );
       })
       .finally(() => setLoading(false));
   };
@@ -45,15 +55,8 @@ export function SetBranchRelease({
         closeModal={() => setIsOpen(false)}
       >
         <p>
-          Are you sure you want to rollback branch
-          {' '}
-          <strong>{branchName}</strong>
-          {' '}
-          to release
-          {' '}
-          <strong>{releaseName}</strong>
-          {' '}
-          ?
+          Are you sure you want to rollback branch <strong>{branchName}</strong>{" "}
+          to release <strong>{releaseName}</strong> ?
         </p>
         <div className="d-flex align-items-center justify-content-end">
           <button

--- a/ui/src/components/sites/branches/settings/BranchGeneralSettings.tsx
+++ b/ui/src/components/sites/branches/settings/BranchGeneralSettings.tsx
@@ -1,11 +1,12 @@
-import { FormProvider, useForm } from 'react-hook-form';
-import React, { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { Site, SiteDomain } from '../../site';
-import { useSite } from '../../SiteView';
-import { axios } from '../../../../providers/axios';
-import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import { FormProvider, useForm } from "react-hook-form";
+import React, { useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { Site, SiteDomain } from "../../site";
+import { useSite } from "../../SiteView";
+import { axios } from "../../../../providers/axios";
+import { useMountedState } from "../../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../../utils/extract-error-message";
 
 interface Settings {
   name: string;
@@ -18,7 +19,7 @@ export function BranchGeneralSettings() {
   const { site, setSite } = useSite();
 
   const methods = useForm<Settings>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const { reset, handleSubmit } = methods;
 
@@ -36,22 +37,22 @@ export function BranchGeneralSettings() {
       .put<Site>(`/api/v1/sites/${siteId}`, updatedSite)
       .then(({ data }) => data)
       .then(setSite)
-      .then(() => toast.success('Site saved'))
-      .catch(err => toast.error(`Could not update site: ${err}`))
+      .then(() => toast.success("Site saved"))
+      .catch((err) =>
+        toast.error(`Could not update site: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   };
 
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-
         {/* <div className="mt-4 card"> */}
         {/*  <div className="card-header no-border d-flex justify-content-between"> */}
         {/*    <strong>Current release</strong> */}
         {/*    <SelectMainBranch siteId={siteId} /> */}
         {/*  </div> */}
         {/* </div> */}
-
       </form>
     </FormProvider>
   );

--- a/ui/src/components/sites/headers/SiteHeaders.tsx
+++ b/ui/src/components/sites/headers/SiteHeaders.tsx
@@ -1,18 +1,19 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { useParams } from 'react-router-dom';
-import { Header } from '../branches/header';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { Branch } from '../branches/branch';
-import { HeaderList } from './HeaderList';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { axios } from '../../../providers/axios';
-import { useSiteHeaders } from './use-site-headers';
+import React from "react";
+import { toast } from "react-toastify";
+import { useParams } from "react-router-dom";
+import { Header } from "../branches/header";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { Branch } from "../branches/branch";
+import { HeaderList } from "./HeaderList";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { axios } from "../../../providers/axios";
+import { useSiteHeaders } from "./use-site-headers";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function useSetSiteHeaders(
   siteId: string,
-  setHeaders: (headers: Header[]) => void,
+  setHeaders: (headers: Header[]) => void
 ) {
   const [loading, setLoading] = useMountedState(false);
 
@@ -24,10 +25,10 @@ function useSetSiteHeaders(
       })
       .then(({ data }) => {
         setHeaders(data.headers);
-        toast.success('Saved branch headers');
+        toast.success("Saved branch headers");
       })
-      .catch(err => {
-        toast.error(`Could not save headers: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not save headers: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);
@@ -43,12 +44,15 @@ function useSetSiteHeaders(
 export function SiteHeaders() {
   const { siteId } = useParams<any>();
   const { headers, setHeaders, loading, error } = useSiteHeaders(siteId);
-  const { loading: updating, updateHeaders } = useSetSiteHeaders(siteId, setHeaders);
+  const { loading: updating, updateHeaders } = useSetSiteHeaders(
+    siteId,
+    setHeaders
+  );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <div className="mt-4">
       <HeaderList

--- a/ui/src/components/sites/releases/DeleteRelease.tsx
+++ b/ui/src/components/sites/releases/DeleteRelease.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function DeleteRelease({
-  releaseId, className, children, onDelete,
+  releaseId,
+  className,
+  children,
+  onDelete,
 }: {
   releaseId: string;
   children: any;
@@ -24,8 +28,8 @@ export function DeleteRelease({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete release: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete release: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/releases/Releases.tsx
+++ b/ui/src/components/sites/releases/Releases.tsx
@@ -1,24 +1,31 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { LoadMore } from '../../../commons/components/LoadMore';
-import { AlertError } from '../../../commons/components/AlertError';
-import { getReleases, ReleaseSearchQuery } from './get-releases';
-import { Release } from './release';
-import { CodeSnippet } from '../../../commons/components/CodeSnippet';
-import { ReleaseIcon } from '../../icons/ReleaseIcon';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { ReleaseView } from './ReleaseView';
-import { SearchInput } from './SearchInput';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { useBranch } from '../branches/BranchView';
-import { useRoom } from '../../../websockets/use-room';
-import { EventType } from '../../../websockets/event-type';
-import { Site } from '../site';
-import { useEnv } from '../../../providers/EnvProvider';
+import React, { useEffect, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { LoadMore } from "../../../commons/components/LoadMore";
+import { AlertError } from "../../../commons/components/AlertError";
+import { getReleases, ReleaseSearchQuery } from "./get-releases";
+import { Release } from "./release";
+import { CodeSnippet } from "../../../commons/components/CodeSnippet";
+import { ReleaseIcon } from "../../icons/ReleaseIcon";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { ReleaseView } from "./ReleaseView";
+import { SearchInput } from "./SearchInput";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { useBranch } from "../branches/BranchView";
+import { useRoom } from "../../../websockets/use-room";
+import { EventType } from "../../../websockets/event-type";
+import { Site } from "../site";
+import { useEnv } from "../../../providers/EnvProvider";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
-function UploadReleaseSnippet({ siteId, className }: { siteId: string; className? }) {
+function UploadReleaseSnippet({
+  siteId,
+  className,
+}: {
+  siteId: string;
+  className?;
+}) {
   const env = useEnv();
   const snippet = `npx @getmeli/cli upload \\
     --url ${env.MELI_URL} \\
@@ -26,7 +33,9 @@ function UploadReleaseSnippet({ siteId, className }: { siteId: string; className
     --token <token> \\
     <path>`;
   return (
-    <CodeSnippet language="shell" className={className}>{snippet}</CodeSnippet>
+    <CodeSnippet language="shell" className={className}>
+      {snippet}
+    </CodeSnippet>
   );
 }
 
@@ -40,7 +49,7 @@ function HowToUpload({ children }: { children: any }) {
       <button
         type="button"
         className="link"
-        onClick={e => {
+        onClick={(e) => {
           e.preventDefault();
           openModal();
         }}
@@ -63,25 +72,35 @@ export function Releases() {
   const itemsRef = useRef<Release[]>([]);
   const [canLoadMore, setCanLoadMore] = useState(false);
   const [searching, setSearching] = useState(false);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState("");
   const searchQueryRef = useRef<ReleaseSearchQuery>({
-    search: '',
+    search: "",
     page: 0,
     size: 10,
     branch: branchContext?.branch?._id,
   });
-  const [searchQuery, setSearchQuery] = useState<ReleaseSearchQuery>(searchQueryRef.current);
+  const [searchQuery, setSearchQuery] = useState<ReleaseSearchQuery>(
+    searchQueryRef.current
+  );
 
-  useRoom<{ site: Site; release: Release }>('site', siteId, [EventType.site_release_created], ({ release }) => {
-    if (search || release.siteId !== siteId) {
-      return;
+  useRoom<{ site: Site; release: Release }>(
+    "site",
+    siteId,
+    [EventType.site_release_created],
+    ({ release }) => {
+      if (search || release.siteId !== siteId) {
+        return;
+      }
+      setItems([release, ...items]);
     }
-    setItems([release, ...items]);
-  });
+  );
 
   useEffect(() => {
     // prevents duplicate calls when search input is initialized
-    if (search === searchQueryRef.current.search || branchContext?.branch?._id === searchQueryRef.current.branch) {
+    if (
+      search === searchQueryRef.current.search ||
+      branchContext?.branch?._id === searchQueryRef.current.branch
+    ) {
       return;
     }
 
@@ -120,14 +139,16 @@ export function Releases() {
     setLoading(true);
 
     getReleases(siteId, searchQuery)
-      .then(data => {
-        itemsRef.current = searchQuery.search ? data.items : [...itemsRef.current, ...data.items];
+      .then((data) => {
+        itemsRef.current = searchQuery.search
+          ? data.items
+          : [...itemsRef.current, ...data.items];
         setItems(itemsRef.current);
         setCanLoadMore(itemsRef.current.length !== data.count);
       })
       .catch(setError)
-      .catch(err => {
-        toast.error(`Could not list releases: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not list releases: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);
@@ -142,15 +163,10 @@ export function Releases() {
     });
   };
 
-  const uploadSnippet = (
-    <UploadReleaseSnippet siteId={siteId}/>
-  );
+  const uploadSnippet = <UploadReleaseSnippet siteId={siteId} />;
 
   const emptyList = (
-    <EmptyList
-      icon={<ReleaseIcon/>}
-      title="No releases"
-    >
+    <EmptyList icon={<ReleaseIcon />} title="No releases">
       <p>There are no releases yet, use our CLI to upload one</p>
       {uploadSnippet}
     </EmptyList>
@@ -161,7 +177,7 @@ export function Releases() {
   };
 
   const onChange = (changed: Release) => {
-    setItems(items.map(item => (item._id === changed._id ? changed : item)));
+    setItems(items.map((item) => (item._id === changed._id ? changed : item)));
   };
 
   return (
@@ -173,9 +189,7 @@ export function Releases() {
           setSearch={setSearch}
           placeholder="Search releases"
         />
-        <HowToUpload>
-          {uploadSnippet}
-        </HowToUpload>
+        <HowToUpload>{uploadSnippet}</HowToUpload>
       </div>
       {items.length === 0 ? (
         searchQuery.search ? (
@@ -185,7 +199,7 @@ export function Releases() {
         )
       ) : (
         <ul className="list-group">
-          {items.map(release => (
+          {items.map((release) => (
             <ReleaseView
               key={release._id}
               siteId={siteId}
@@ -195,15 +209,9 @@ export function Releases() {
             />
           ))}
           {canLoadMore && (
-            <LoadMore
-              onClick={nextPage}
-              loading={loading}
-              disabled={loading}
-            />
+            <LoadMore onClick={nextPage} loading={loading} disabled={loading} />
           )}
-          {error && (
-            <AlertError error={error} className="mt-4"/>
-          )}
+          {error && <AlertError error={error} className="mt-4" />}
         </ul>
       )}
     </>

--- a/ui/src/components/sites/releases/RenameRelease.tsx
+++ b/ui/src/components/sites/releases/RenameRelease.tsx
@@ -1,32 +1,40 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { FormProvider, useForm } from 'react-hook-form';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Release } from './release';
-import { ReleaseNameInput } from './ReleaseNameInput';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import { FormProvider, useForm } from "react-hook-form";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Release } from "./release";
+import { ReleaseNameInput } from "./ReleaseNameInput";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
-function ModalContent({ releaseId, onRenamed }: {
+function ModalContent({
+  releaseId,
+  onRenamed,
+}: {
   releaseId: string;
   onRenamed: (release: Release) => void;
 }) {
   const methods = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
-  const { handleSubmit, formState: { isDirty } } = methods;
+  const {
+    handleSubmit,
+    formState: { isDirty },
+  } = methods;
 
-  const onChange = formData => axios
-    .put<Release>(`/api/v1/releases/${releaseId}`, formData)
-    .then(({ data }) => data)
-    .then(onRenamed)
-    .catch(err => {
-      toast.error(`Could not rename release: ${err}`);
-    });
+  const onChange = (formData) =>
+    axios
+      .put<Release>(`/api/v1/releases/${releaseId}`, formData)
+      .then(({ data }) => data)
+      .then(onRenamed)
+      .catch((err) => {
+        toast.error(`Could not rename release: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -42,7 +50,7 @@ function ModalContent({ releaseId, onRenamed }: {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <ReleaseNameInput setInputRef={setInputRef}/>
+        <ReleaseNameInput setInputRef={setInputRef} />
         <div className="d-flex justify-content-end">
           <Button
             type="submit"
@@ -59,7 +67,10 @@ function ModalContent({ releaseId, onRenamed }: {
 }
 
 export function RenameRelease({
-  children, className, releaseId, onRenamed,
+  children,
+  className,
+  releaseId,
+  onRenamed,
 }: {
   children;
   className?;
@@ -70,21 +81,18 @@ export function RenameRelease({
   const openModal = () => setIsOpen(true);
   const closeModal = () => setIsOpen(false);
 
-  const renamed = val => {
+  const renamed = (val) => {
     onRenamed(val);
     closeModal();
   };
 
   return (
     <>
-      <div
-        onClick={openModal}
-        className={className}
-      >
+      <div onClick={openModal} className={className}>
         {children}
       </div>
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Rename release">
-        <ModalContent onRenamed={renamed} releaseId={releaseId}/>
+        <ModalContent onRenamed={renamed} releaseId={releaseId} />
       </CardModal>
     </>
   );

--- a/ui/src/components/sites/search/SearchModal.tsx
+++ b/ui/src/components/sites/search/SearchModal.tsx
@@ -1,17 +1,24 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { BehaviorSubject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
-import { toast } from 'react-toastify';
-import styles from './SearchModal.module.scss';
-import { routerHistory } from '../../../providers/history';
-import { Loader } from '../../../commons/components/Loader';
-import { SiteCard } from '../SiteCard';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useSites } from '../use-sites';
+import React, { useEffect, useRef, useState } from "react";
+import { BehaviorSubject } from "rxjs";
+import { debounceTime, distinctUntilChanged, filter } from "rxjs/operators";
+import { CSSTransition, TransitionGroup } from "react-transition-group";
+import { toast } from "react-toastify";
+import styles from "./SearchModal.module.scss";
+import { routerHistory } from "../../../providers/history";
+import { Loader } from "../../../commons/components/Loader";
+import { SiteCard } from "../SiteCard";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useSites } from "../use-sites";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
-export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModal: () => void }) {
-  const search$ = useRef(new BehaviorSubject(''));
+export function SearchModal({
+  isOpen,
+  closeModal,
+}: {
+  isOpen: boolean;
+  closeModal: () => void;
+}) {
+  const search$ = useRef(new BehaviorSubject(""));
   const [searchInputRef, setSearchInputRef] = useState<HTMLInputElement>();
 
   const { loading, error, data: sites, cb: listSites } = useSites();
@@ -20,11 +27,11 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
     if (isOpen) {
       const subs = search$.current
         .pipe(
-          filter(value => !value || value.length >= 3),
+          filter((value) => !value || value.length >= 3),
           debounceTime(200),
-          distinctUntilChanged(),
+          distinctUntilChanged()
         )
-        .subscribe(value => {
+        .subscribe((value) => {
           listSites({
             search: value || undefined,
             page: 0,
@@ -37,7 +44,7 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
 
   useEffect(() => {
     if (error) {
-      toast.error(`Could not search sites: ${error}`);
+      toast.error(`Could not search sites: ${extractErrorMessage(error)}`);
     }
   }, [error]);
 
@@ -49,7 +56,7 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
     }
   }, [isOpen, searchInputRef]);
 
-  const onItemClick = site => {
+  const onItemClick = (site) => {
     routerHistory.push(`/sites/${site._id}`);
     closeModal();
   };
@@ -69,7 +76,7 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
                 type="text"
                 ref={setSearchInputRef}
                 className="form-control"
-                onChange={e => search$.current.next(e.target.value)}
+                onChange={(e) => search$.current.next(e.target.value)}
                 placeholder="Search sites"
               />
               {loading && (
@@ -80,17 +87,20 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
             </div>
             {sites && (
               <div className="mt-3">
-                {sites.items.length === 0 && (
-                  <strong>No results</strong>
-                )}
+                {sites.items.length === 0 && <strong>No results</strong>}
                 <TransitionGroup>
-                  {sites.items.length !== 0 && sites.items.map(site => (
-                    <CSSTransition key={site._id} timeout={500} classNames="fade-down">
-                      <div className="mb-2" onClick={() => onItemClick(site)}>
-                        <SiteCard site={site} className="bg-light" />
-                      </div>
-                    </CSSTransition>
-                  ))}
+                  {sites.items.length !== 0 &&
+                    sites.items.map((site) => (
+                      <CSSTransition
+                        key={site._id}
+                        timeout={500}
+                        classNames="fade-down"
+                      >
+                        <div className="mb-2" onClick={() => onItemClick(site)}>
+                          <SiteCard site={site} className="bg-light" />
+                        </div>
+                      </CSSTransition>
+                    ))}
                 </TransitionGroup>
               </div>
             )}

--- a/ui/src/components/sites/settings/GeneralSettingsForm.tsx
+++ b/ui/src/components/sites/settings/GeneralSettingsForm.tsx
@@ -1,22 +1,31 @@
-import { useParams } from 'react-router-dom';
-import { Controller, FormProvider, useFieldArray, useForm } from 'react-hook-form';
-import React, { useEffect } from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { useSite } from '../SiteView';
-import { Site, SiteDomain } from '../site';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { axios } from '../../../providers/axios';
-import styles from './SiteSettings.module.scss';
-import { CopyToClipboard } from '../../../commons/components/CopyToClipboard';
-import { SiteNameInput } from './SiteNameInput';
-import { COLOR_PATTERN, required } from '../../../commons/components/forms/form-constants';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { SelectMainBranch } from './SelectMainBranch';
-import { Toggle } from '../../../commons/components/forms/Toggle';
-import { DocsLink } from '../../../commons/components/DocsLink';
-import { DomainForm } from './DomainForm';
-import { Button } from '../../../commons/components/Button';
+import { useParams } from "react-router-dom";
+import {
+  Controller,
+  FormProvider,
+  useFieldArray,
+  useForm,
+} from "react-hook-form";
+import React, { useEffect } from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { useSite } from "../SiteView";
+import { Site, SiteDomain } from "../site";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { axios } from "../../../providers/axios";
+import styles from "./SiteSettings.module.scss";
+import { CopyToClipboard } from "../../../commons/components/CopyToClipboard";
+import { SiteNameInput } from "./SiteNameInput";
+import {
+  COLOR_PATTERN,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { InputError } from "../../../commons/components/forms/InputError";
+import { SelectMainBranch } from "./SelectMainBranch";
+import { Toggle } from "../../../commons/components/forms/Toggle";
+import { DocsLink } from "../../../commons/components/DocsLink";
+import { DomainForm } from "./DomainForm";
+import { Button } from "../../../commons/components/Button";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface Settings {
   name: string;
@@ -29,14 +38,19 @@ export function GeneralSettingsForm() {
   const { site, setSite } = useSite();
 
   const methods = useForm<Settings>({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const {
-    errors, register, control, reset, handleSubmit, formState: { isDirty },
+    errors,
+    register,
+    control,
+    reset,
+    handleSubmit,
+    formState: { isDirty },
   } = methods;
   const domains = useFieldArray<SiteDomain>({
     control,
-    name: 'domains',
+    name: "domains",
   });
 
   useEffect(() => {
@@ -53,19 +67,17 @@ export function GeneralSettingsForm() {
       .put<Site>(`/api/v1/sites/${siteId}`, updatedSite)
       .then(({ data }) => data)
       .then(setSite)
-      .then(() => toast.success('Site saved'))
-      .catch(err => toast.error(`Could not update site: ${err}`))
+      .then(() => toast.success("Site saved"))
+      .catch((err) =>
+        toast.error(`Could not update site: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   };
 
   return (
     <>
       <FormProvider {...methods}>
-        <form
-          onSubmit={handleSubmit(onSubmit)}
-          className={styles.form}
-        >
-
+        <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
           <div className="mt-4 card">
             <div className="card-header no-border d-flex justify-content-between">
               <strong>Site ID</strong>
@@ -80,9 +92,11 @@ export function GeneralSettingsForm() {
               <strong>General</strong>
             </div>
             <div className="card-body">
-              <SiteNameInput previousName={site.name}/>
+              <SiteNameInput previousName={site.name} />
               <div className="form-group">
-                <label htmlFor="color" className="form-label">Color</label>
+                <label htmlFor="color" className="form-label">
+                  Color
+                </label>
                 <input
                   type="color"
                   id="color"
@@ -95,10 +109,10 @@ export function GeneralSettingsForm() {
                   autoComplete="off"
                   defaultValue="#000000"
                 />
-                <InputError error={errors} path="color"/>
+                <InputError error={errors} path="color" />
               </div>
 
-              <SelectMainBranch siteId={siteId}/>
+              <SelectMainBranch siteId={siteId} />
             </div>
           </div>
 
@@ -111,7 +125,10 @@ export function GeneralSettingsForm() {
                   <Toggle value={value} onChange={onChange} className="w-100">
                     <div className="d-flex justify-content-between flex-grow-1">
                       <strong>Single page application (SPA) mode</strong>
-                      <DocsLink href="https://docs.meli.sh/get-started/single-page-applications-spa" className="ml-2"/>
+                      <DocsLink
+                        href="https://docs.meli.sh/get-started/single-page-applications-spa"
+                        className="ml-2"
+                      />
                     </div>
                   </Toggle>
                 )}
@@ -136,10 +153,12 @@ export function GeneralSettingsForm() {
                 ))}
                 <button
                   type="button"
-                  className={classNames('mt-3', styles.add)}
-                  onClick={() => domains.append({
-                    exposeBranches: false,
-                  })}
+                  className={classNames("mt-3", styles.add)}
+                  onClick={() =>
+                    domains.append({
+                      exposeBranches: false,
+                    })
+                  }
                 >
                   Add domain
                 </button>
@@ -167,7 +186,6 @@ export function GeneralSettingsForm() {
               Save
             </Button>
           </div>
-
         </form>
       </FormProvider>
     </>

--- a/ui/src/components/sites/settings/SiteNameInput.tsx
+++ b/ui/src/components/sites/settings/SiteNameInput.tsx
@@ -1,12 +1,20 @@
-import { useFormContext } from 'react-hook-form';
-import React from 'react';
-import { toast } from 'react-toastify';
-import { isSubdomain, maxLength, required } from '../../../commons/components/forms/form-constants';
-import { debounceTime } from '../../../utils/debounce-time';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { axios } from '../../../providers/axios';
+import { useFormContext } from "react-hook-form";
+import React from "react";
+import { toast } from "react-toastify";
+import {
+  isSubdomain,
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { debounceTime } from "../../../utils/debounce-time";
+import { InputError } from "../../../commons/components/forms/InputError";
+import { axios } from "../../../providers/axios";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
-async function validateName(name: string, previousName?: string): Promise<string | undefined> {
+async function validateName(
+  name: string,
+  previousName?: string
+): Promise<string | undefined> {
   if (!name) {
     return undefined;
   }
@@ -18,19 +26,22 @@ async function validateName(name: string, previousName?: string): Promise<string
       name,
     })
     .then(({ data }) => data || undefined)
-    .catch(err => {
-      toast.error(`Could not validate site name: ${err}`);
+    .catch((err) => {
+      toast.error(`Could not validate site name: ${extractErrorMessage(err)}`);
       return undefined;
     });
 }
 
-export function SiteNameInput({ setInputRef, previousName }: {
+export function SiteNameInput({
+  setInputRef,
+  previousName,
+}: {
   setInputRef?: (input: HTMLInputElement) => void;
   previousName?: string;
 }) {
   const { register, errors } = useFormContext();
 
-  const ref = input => {
+  const ref = (input) => {
     if (setInputRef) {
       setInputRef(input);
     }
@@ -38,13 +49,18 @@ export function SiteNameInput({ setInputRef, previousName }: {
       required,
       maxLength: maxLength(),
       pattern: isSubdomain,
-      validate: debounceTime<string | undefined>(val => validateName(val, previousName), 300),
+      validate: debounceTime<string | undefined>(
+        (val) => validateName(val, previousName),
+        300
+      ),
     })(input);
   };
 
   return (
     <div className="form-group">
-      <label htmlFor="name" className="form-label">Name</label>
+      <label htmlFor="name" className="form-label">
+        Name
+      </label>
       <input
         type="text"
         id="name"
@@ -54,7 +70,7 @@ export function SiteNameInput({ setInputRef, previousName }: {
         placeholder="lisa"
         autoComplete="off"
       />
-      <InputError error={errors} path="name"/>
+      <InputError error={errors} path="name" />
     </div>
   );
 }

--- a/ui/src/components/sites/settings/SitePassword.tsx
+++ b/ui/src/components/sites/settings/SitePassword.tsx
@@ -1,22 +1,28 @@
-import React, { useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Toggle } from '../../../commons/components/forms/Toggle';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Button } from '../../../commons/components/Button';
-import { InputError } from '../../../commons/components/forms/InputError';
-import { maxLength, required } from '../../../commons/components/forms/form-constants';
-import { axios } from '../../../providers/axios';
-import { randomString } from '../../../commons/utils/random-string';
-import { Site } from '../site';
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Toggle } from "../../../commons/components/forms/Toggle";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Button } from "../../../commons/components/Button";
+import { InputError } from "../../../commons/components/forms/InputError";
+import {
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { axios } from "../../../providers/axios";
+import { randomString } from "../../../commons/utils/random-string";
+import { Site } from "../site";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 interface FormData {
   password: string;
 }
 
 export function SitePassword({
-  site, onChange, className,
+  site,
+  onChange,
+  className,
 }: {
   site: Site;
   onChange: (site: Site) => void;
@@ -32,10 +38,8 @@ export function SitePassword({
     setRandomSecret(randomString(16));
   }, [isOpen]);
 
-  const {
-    register, errors, handleSubmit,
-  } = useForm<FormData>({
-    mode: 'onChange',
+  const { register, errors, handleSubmit } = useForm<FormData>({
+    mode: "onChange",
   });
 
   const [loading, setLoading] = useState(false);
@@ -48,8 +52,8 @@ export function SitePassword({
         onChange(data);
         closeModal();
       })
-      .catch(err => {
-        toast.error(`Could not set site password: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not set site password: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -59,8 +63,10 @@ export function SitePassword({
     axios
       .delete<Site>(`/api/v1/sites/${site._id}/password`)
       .then(({ data }) => onChange(data))
-      .catch(err => {
-        toast.error(`Could not remove site password: ${err}`);
+      .catch((err) => {
+        toast.error(
+          `Could not remove site password: ${extractErrorMessage(err)}`
+        );
       })
       .finally(() => setLoading(false));
   };
@@ -71,24 +77,26 @@ export function SitePassword({
         value={!!site.hasPassword}
         onChange={() => (site.hasPassword ? removePassword() : openModal())}
         loading={site.hasPassword && loading}
-        className={classNames(className, 'w-100 font-weight-bold')}
+        className={classNames(className, "w-100 font-weight-bold")}
       >
-        Password protection
-        {' '}
+        Password protection{" "}
         {site.hasPassword && (
           <>
-            {' '}
-            (user name is
-            {' '}
-            <code>user</code>
-            )
+            {" "}
+            (user name is <code>user</code>)
           </>
         )}
       </Toggle>
-      <CardModal isOpen={isOpen} closeModal={closeModal} title="Set site password">
+      <CardModal
+        isOpen={isOpen}
+        closeModal={closeModal}
+        title="Set site password"
+      >
         <form onSubmit={handleSubmit(setPassword)}>
           <div className="form-group">
-            <label htmlFor="password" className="form-label">Password</label>
+            <label htmlFor="password" className="form-label">
+              Password
+            </label>
             <input
               type="text"
               id="password"
@@ -102,7 +110,7 @@ export function SitePassword({
               autoComplete="off"
               defaultValue={randomSecret}
             />
-            <InputError error={errors} path="password"/>
+            <InputError error={errors} path="password" />
           </div>
           <div className="d-flex justify-content-end">
             <Button

--- a/ui/src/components/sites/tokens/AddToken.tsx
+++ b/ui/src/components/sites/tokens/AddToken.tsx
@@ -1,40 +1,50 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { useForm } from 'react-hook-form';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { Token } from './token';
-import { maxLength, required } from '../../../commons/components/forms/form-constants';
-import { InputError } from '../../../commons/components/forms/InputError';
-import styles from './AddToken.module.scss';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { useForm } from "react-hook-form";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { Token } from "./token";
+import {
+  maxLength,
+  required,
+} from "../../../commons/components/forms/form-constants";
+import { InputError } from "../../../commons/components/forms/InputError";
+import styles from "./AddToken.module.scss";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function AddTokenModal({
-  closeModal, siteId, onAdded,
+  closeModal,
+  siteId,
+  onAdded,
 }: {
   closeModal;
   siteId: string;
   onAdded: (token: Token) => void;
 }) {
   const {
-    register, errors, handleSubmit, formState: { isDirty },
+    register,
+    errors,
+    handleSubmit,
+    formState: { isDirty },
   } = useForm({
-    mode: 'onChange',
+    mode: "onChange",
   });
   const [loading, setLoading] = useMountedState(false);
 
-  const onChange = token => axios
-    .post(`/api/v1/sites/${siteId}/tokens`, token)
-    .then(({ data }) => {
-      onAdded(data);
-    })
-    .then(closeModal)
-    .catch(err => {
-      toast.error(`Could not create token: ${err}`);
-    });
+  const onChange = (token) =>
+    axios
+      .post(`/api/v1/sites/${siteId}/tokens`, token)
+      .then(({ data }) => {
+        onAdded(data);
+      })
+      .then(closeModal)
+      .catch((err) => {
+        toast.error(`Could not create token: ${extractErrorMessage(err)}`);
+      });
 
-  const onSubmit = data => {
+  const onSubmit = (data) => {
     setLoading(true);
     onChange(data).finally(() => setLoading(false));
   };
@@ -55,7 +65,7 @@ function AddTokenModal({
           placeholder="Steve's token"
           autoComplete="off"
         />
-        <InputError error={errors} path="name"/>
+        <InputError error={errors} path="name" />
       </div>
       <div className="d-flex justify-content-end">
         <Button
@@ -72,7 +82,10 @@ function AddTokenModal({
 }
 
 export function AddToken({
-  children, className, siteId, onAdded,
+  children,
+  className,
+  siteId,
+  onAdded,
 }: {
   children;
   className?;
@@ -89,7 +102,11 @@ export function AddToken({
         {children}
       </div>
       <CardModal isOpen={isOpen} closeModal={closeModal} title="Create token">
-        <AddTokenModal closeModal={closeModal} siteId={siteId} onAdded={onAdded}/>
+        <AddTokenModal
+          closeModal={closeModal}
+          siteId={siteId}
+          onAdded={onAdded}
+        />
       </CardModal>
     </>
   );

--- a/ui/src/components/sites/tokens/DeleteToken.tsx
+++ b/ui/src/components/sites/tokens/DeleteToken.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function DeleteToken({
-  siteId, tokenId, className, children, onDelete,
+  siteId,
+  tokenId,
+  className,
+  children,
+  onDelete,
 }: {
   siteId: string;
   tokenId: string;
@@ -25,8 +30,8 @@ export function DeleteToken({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete token: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete token: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/tokens/TokenList.tsx
+++ b/ui/src/components/sites/tokens/TokenList.tsx
@@ -1,17 +1,18 @@
-import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { Token } from './token';
-import { axios } from '../../../providers/axios';
-import { AddToken } from './AddToken';
-import { TokenView } from './TokenView';
-import styles from './TokenList.module.scss';
-import { TokenIcon } from '../../icons/TokenIcon';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { Token } from "./token";
+import { axios } from "../../../providers/axios";
+import { AddToken } from "./AddToken";
+import { TokenView } from "./TokenView";
+import styles from "./TokenList.module.scss";
+import { TokenIcon } from "../../icons/TokenIcon";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function sortTokens(a: Token, b: Token): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -26,15 +27,18 @@ export function TokenList() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get(`/api/v1/sites/${siteId}/tokens`)
+    axios
+      .get(`/api/v1/sites/${siteId}/tokens`)
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list tokens: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list tokens: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [siteId, setLoading]);
 
-  const onAdd = token => {
+  const onAdd = (token) => {
     setItems([token, ...items].sort(sortTokens));
   };
 
@@ -43,10 +47,7 @@ export function TokenList() {
   };
 
   const emptyList = (
-    <EmptyList
-      icon={<TokenIcon/>}
-      title="No tokens"
-    >
+    <EmptyList icon={<TokenIcon />} title="No tokens">
       <p>There are no tokens yet</p>
       <AddToken siteId={siteId} onAdded={onAdd}>
         <button type="button" className="btn btn-primary">
@@ -57,9 +58,9 @@ export function TokenList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       {items.length === 0 ? (
@@ -69,11 +70,14 @@ export function TokenList() {
           <AddToken
             siteId={siteId}
             onAdded={onAdd}
-            className={classNames('list-group-item list-group-item-action', styles.add)}
+            className={classNames(
+              "list-group-item list-group-item-action",
+              styles.add
+            )}
           >
             Add token
           </AddToken>
-          {items.map(token => (
+          {items.map((token) => (
             <TokenView
               key={token._id}
               siteId={siteId}

--- a/ui/src/components/user/UserSecurity.tsx
+++ b/ui/src/components/user/UserSecurity.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { useMountedState } from '../../commons/hooks/use-mounted-state';
-import { axios } from '../../providers/axios';
-import { Button } from '../../commons/components/Button';
-import { useAuth } from '../../providers/AuthProvider';
+import React from "react";
+import { toast } from "react-toastify";
+import { useMountedState } from "../../commons/hooks/use-mounted-state";
+import { axios } from "../../providers/axios";
+import { Button } from "../../commons/components/Button";
+import { useAuth } from "../../providers/AuthProvider";
+import { extractErrorMessage } from "../../utils/extract-error-message";
 
 function Disconnect() {
   const [loading, setLoading] = useMountedState(false);
@@ -16,8 +17,8 @@ function Disconnect() {
       .then(() => {
         signOut();
       })
-      .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -26,7 +27,11 @@ function Disconnect() {
     <div className="card">
       <div className="card-header no-border d-flex justify-content-between">
         <strong>Disconnect from all devices</strong>
-        <Button className="btn btn-danger" loading={loading} onClick={disconnect}>
+        <Button
+          className="btn btn-danger"
+          loading={loading}
+          onClick={disconnect}
+        >
           disconnect
         </Button>
       </div>
@@ -37,7 +42,7 @@ function Disconnect() {
 export function UserSecurity() {
   return (
     <>
-      <Disconnect/>
+      <Disconnect />
     </>
   );
 }

--- a/ui/src/components/user/api-tokens/AddApiToken.tsx
+++ b/ui/src/components/user/api-tokens/AddApiToken.tsx
@@ -1,25 +1,25 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { axios } from '../../../providers/axios';
-import { ApiToken } from './api-token';
-import { ApiTokenForm, ApiTokenFormData } from './ApiTokenForm';
-import { routerHistory } from '../../../providers/history';
+import React from "react";
+import { toast } from "react-toastify";
+import { axios } from "../../../providers/axios";
+import { ApiToken } from "./api-token";
+import { ApiTokenForm, ApiTokenFormData } from "./ApiTokenForm";
+import { routerHistory } from "../../../providers/history";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function AddApiToken() {
-  const onChange = (data: ApiTokenFormData): Promise<void> => axios
-    .post<ApiToken>(`/api/v1/api-tokens`, {
-      name: data.name,
-      activesAt: data.activePeriod.from,
-      expiresAt: data.activePeriod.to,
-      scopes: data.scopes,
-    })
-    .then(() => {
-      routerHistory.push('/user/api-tokens');
-    })
-    .catch(err => {
-      toast.error(`Could not create api token: ${err}`);
-    });
-  return (
-    <ApiTokenForm onChange={onChange}/>
-  );
+  const onChange = (data: ApiTokenFormData): Promise<void> =>
+    axios
+      .post<ApiToken>(`/api/v1/api-tokens`, {
+        name: data.name,
+        activesAt: data.activePeriod.from,
+        expiresAt: data.activePeriod.to,
+        scopes: data.scopes,
+      })
+      .then(() => {
+        routerHistory.push("/user/api-tokens");
+      })
+      .catch((err) => {
+        toast.error(`Could not create api token: ${extractErrorMessage(err)}`);
+      });
+  return <ApiTokenForm onChange={onChange} />;
 }

--- a/ui/src/components/user/api-tokens/ApiTokenList.tsx
+++ b/ui/src/components/user/api-tokens/ApiTokenList.tsx
@@ -1,16 +1,17 @@
-import React, { useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import classNames from 'classnames';
-import { Link, useRouteMatch } from 'react-router-dom';
-import { EmptyList } from '../../../commons/components/EmptyList';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { ApiToken } from './api-token';
-import { axios } from '../../../providers/axios';
-import styles from './ApiTokenList.module.scss';
-import { TokenIcon } from '../../icons/TokenIcon';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { ApiTokenActivationPeriod } from './ApiTokenActivationPeriod';
+import React, { useEffect, useState } from "react";
+import { toast } from "react-toastify";
+import classNames from "classnames";
+import { Link, useRouteMatch } from "react-router-dom";
+import { EmptyList } from "../../../commons/components/EmptyList";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { ApiToken } from "./api-token";
+import { axios } from "../../../providers/axios";
+import styles from "./ApiTokenList.module.scss";
+import { TokenIcon } from "../../icons/TokenIcon";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { ApiTokenActivationPeriod } from "./ApiTokenActivationPeriod";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 function sortTokens(a: ApiToken, b: ApiToken): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -26,19 +27,19 @@ export function ApiTokenList() {
   useEffect(() => {
     setLoading(true);
     setError(undefined);
-    axios.get<ApiToken[]>(`/api/v1/api-tokens`)
+    axios
+      .get<ApiToken[]>(`/api/v1/api-tokens`)
       .then(({ data }) => data.sort(sortTokens))
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list tokens: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not list tokens: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [setLoading]);
 
   const emptyList = (
-    <EmptyList
-      icon={<TokenIcon/>}
-      title="No tokens"
-    >
+    <EmptyList icon={<TokenIcon />} title="No tokens">
       <p>There are no tokens yet</p>
       <Link to={`${url}/add`}>
         <button type="button" className="btn btn-primary">
@@ -49,9 +50,9 @@ export function ApiTokenList() {
   );
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       {items.length === 0 ? (
@@ -60,11 +61,14 @@ export function ApiTokenList() {
         <ul className="list-group">
           <Link
             to={`${url}/add`}
-            className={classNames('list-group-item list-group-item-action', styles.add)}
+            className={classNames(
+              "list-group-item list-group-item-action",
+              styles.add
+            )}
           >
             Add token
           </Link>
-          {items.map(apiToken => (
+          {items.map((apiToken) => (
             <Link
               key={apiToken._id}
               to={`${url}/${apiToken._id}`}
@@ -75,7 +79,7 @@ export function ApiTokenList() {
               </div>
 
               <div className="d-flex align-items-center">
-                <ApiTokenActivationPeriod apiToken={apiToken}/>
+                <ApiTokenActivationPeriod apiToken={apiToken} />
               </div>
             </Link>
           ))}

--- a/ui/src/components/user/api-tokens/ApiTokenView.tsx
+++ b/ui/src/components/user/api-tokens/ApiTokenView.tsx
@@ -1,25 +1,29 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouteMatch } from 'react-router-dom';
-import { toast } from 'react-toastify';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrashAlt } from '@fortawesome/free-regular-svg-icons';
-import { uniqueId } from 'lodash';
-import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
-import { axios } from '../../../providers/axios';
-import { ApiToken } from './api-token';
-import { ApiTokenForm, ApiTokenFormData } from './ApiTokenForm';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
-import { Loader } from '../../../commons/components/Loader';
-import { AlertError } from '../../../commons/components/AlertError';
-import { ButtonIcon } from '../../../commons/components/ButtonIcon';
-import { Dropdown, dropdownToggle } from '../../../commons/components/dropdown/Dropdown';
-import { DropdownLink } from '../../../commons/components/dropdown/DropdownLink';
-import { SubHeader } from '../../SubHeader';
-import { DeleteApiToken } from './DeleteApiToken';
-import { routerHistory } from '../../../providers/history';
-import { ApiTokenActivationPeriod } from './ApiTokenActivationPeriod';
-import { CopyToClipboard } from '../../../commons/components/CopyToClipboard';
-import { routeUp } from '../../../commons/utils/route-up';
+import React, { useCallback, useEffect, useState } from "react";
+import { useParams, useRouteMatch } from "react-router-dom";
+import { toast } from "react-toastify";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTrashAlt } from "@fortawesome/free-regular-svg-icons";
+import { uniqueId } from "lodash";
+import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
+import { axios } from "../../../providers/axios";
+import { ApiToken } from "./api-token";
+import { ApiTokenForm, ApiTokenFormData } from "./ApiTokenForm";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { Loader } from "../../../commons/components/Loader";
+import { AlertError } from "../../../commons/components/AlertError";
+import { ButtonIcon } from "../../../commons/components/ButtonIcon";
+import {
+  Dropdown,
+  dropdownToggle,
+} from "../../../commons/components/dropdown/Dropdown";
+import { DropdownLink } from "../../../commons/components/dropdown/DropdownLink";
+import { SubHeader } from "../../SubHeader";
+import { DeleteApiToken } from "./DeleteApiToken";
+import { routerHistory } from "../../../providers/history";
+import { ApiTokenActivationPeriod } from "./ApiTokenActivationPeriod";
+import { CopyToClipboard } from "../../../commons/components/CopyToClipboard";
+import { routeUp } from "../../../commons/utils/route-up";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function ApiTokenView() {
   const { apiTokenId } = useParams<any>();
@@ -38,23 +42,28 @@ export function ApiTokenView() {
       .then(({ data }) => data)
       .then(setApiToken)
       .catch(setError)
-      .catch(err => toast.error(`Could not get api token: ${err}`))
+      .catch((err) =>
+        toast.error(`Could not get api token: ${extractErrorMessage(err)}`)
+      )
       .finally(() => setLoading(false));
   }, [setLoading, apiTokenId]);
 
   const onChange = useCallback(
-    (formData: ApiTokenFormData): Promise<void> => axios
-      .put<ApiToken>(`/api/v1/api-tokens/${apiTokenId}`, {
-        name: formData.name,
-        activatesAt: formData.activePeriod.from,
-        expiresAt: formData.activePeriod.to,
-        scopes: formData.scopes,
-      })
-      .then(({ data }) => setApiToken(data))
-      .catch(err => {
-        toast.error(`Could not update api token: ${err}`);
-      }),
-    [apiTokenId],
+    (formData: ApiTokenFormData): Promise<void> =>
+      axios
+        .put<ApiToken>(`/api/v1/api-tokens/${apiTokenId}`, {
+          name: formData.name,
+          activatesAt: formData.activePeriod.from,
+          expiresAt: formData.activePeriod.to,
+          scopes: formData.scopes,
+        })
+        .then(({ data }) => setApiToken(data))
+        .catch((err) => {
+          toast.error(
+            `Could not update api token: ${extractErrorMessage(err)}`
+          );
+        }),
+    [apiTokenId]
   );
 
   const onDelete = () => {
@@ -62,25 +71,25 @@ export function ApiTokenView() {
   };
 
   return loading ? (
-    <Loader/>
+    <Loader />
   ) : error ? (
-    <AlertError error={error}/>
+    <AlertError error={error} />
   ) : (
     <>
       <SubHeader className="d-flex align-items-center justify-content-between">
         <div className="d-flex align-items-center">
-          <h5 className="mb-0 d-flex align-items-center">
-            {apiToken.name}
-          </h5>
+          <h5 className="mb-0 d-flex align-items-center">{apiToken.name}</h5>
         </div>
         <div className="d-flex align-items-center">
-          <ApiTokenActivationPeriod apiToken={apiToken}/>
+          <ApiTokenActivationPeriod apiToken={apiToken} />
           <ButtonIcon className="ml-3" {...dropdownToggle(uid)}>
-            <FontAwesomeIcon icon={faEllipsisV}/>
+            <FontAwesomeIcon icon={faEllipsisV} />
           </ButtonIcon>
           <Dropdown id={uid}>
             <DeleteApiToken tokenId={apiTokenId} onDelete={onDelete}>
-              <DropdownLink icon={<FontAwesomeIcon icon={faTrashAlt} fixedWidth/>}>
+              <DropdownLink
+                icon={<FontAwesomeIcon icon={faTrashAlt} fixedWidth />}
+              >
                 Delete
               </DropdownLink>
             </DeleteApiToken>

--- a/ui/src/components/user/api-tokens/DeleteApiToken.tsx
+++ b/ui/src/components/user/api-tokens/DeleteApiToken.tsx
@@ -1,12 +1,16 @@
-import React from 'react';
-import { toast } from 'react-toastify';
-import { Button } from '../../../commons/components/Button';
-import { axios } from '../../../providers/axios';
-import { CardModal } from '../../../commons/components/modals/CardModal';
-import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import React from "react";
+import { toast } from "react-toastify";
+import { Button } from "../../../commons/components/Button";
+import { axios } from "../../../providers/axios";
+import { CardModal } from "../../../commons/components/modals/CardModal";
+import { useMountedState } from "../../../commons/hooks/use-mounted-state";
+import { extractErrorMessage } from "../../../utils/extract-error-message";
 
 export function DeleteApiToken({
-  tokenId, className, children, onDelete,
+  tokenId,
+  className,
+  children,
+  onDelete,
 }: {
   tokenId: string;
   children: any;
@@ -24,8 +28,8 @@ export function DeleteApiToken({
         setIsOpen(false);
         onDelete();
       })
-      .catch(err => {
-        toast.error(`Could not delete api token: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not delete api token: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/providers/AuthProvider.tsx
+++ b/ui/src/providers/AuthProvider.tsx
@@ -1,8 +1,15 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { axios } from './axios';
-import { Loader } from '../commons/components/Loader';
-import { FullPageCentered } from '../commons/components/FullPageCentered';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { toast } from "react-toastify";
+import { axios } from "./axios";
+import { Loader } from "../commons/components/Loader";
+import { FullPageCentered } from "../commons/components/FullPageCentered";
+import { extractErrorMessage } from "../utils/extract-error-message";
 
 export interface User {
   _id: string;
@@ -35,10 +42,10 @@ export function AuthProvider(props) {
       .then(() => setUser(null))
       // force app to reset (TODO graceful logout)
       .then(() => {
-        window.location.href = '/';
+        window.location.href = "/";
       })
-      .catch(err => {
-        toast.error(`Could not sign out properly: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not sign out properly: ${extractErrorMessage(err)}`);
       });
   }, []);
 
@@ -47,8 +54,8 @@ export function AuthProvider(props) {
     axios
       .get(`/api/v1/user`)
       .then(({ data }) => setUser(data))
-      .catch(err => {
-        toast.error(`Could not get user: ${err}`);
+      .catch((err) => {
+        toast.error(`Could not get user: ${extractErrorMessage(err)}`);
         setUser(null);
       })
       .finally(() => {
@@ -61,26 +68,24 @@ export function AuthProvider(props) {
     fetchUser();
   }, [fetchUser]);
 
-  return (
-    !initialized ? (
-      <FullPageCentered>
-        <p>
-          Loading auth
-          <Loader className="ml-2"/>
-        </p>
-      </FullPageCentered>
-    ) : (
-      <AuthContext.Provider
-        value={{
-          initialized,
-          loading,
-          fetchUser,
-          user,
-          setUser,
-          signOut,
-        }}
-        {...props}
-      />
-    )
+  return !initialized ? (
+    <FullPageCentered>
+      <p>
+        Loading auth
+        <Loader className="ml-2" />
+      </p>
+    </FullPageCentered>
+  ) : (
+    <AuthContext.Provider
+      value={{
+        initialized,
+        loading,
+        fetchUser,
+        user,
+        setUser,
+        signOut,
+      }}
+      {...props}
+    />
   );
 }

--- a/ui/src/providers/OrgProvider.tsx
+++ b/ui/src/providers/OrgProvider.tsx
@@ -1,12 +1,19 @@
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { toast } from 'react-toastify';
-import { axios } from './axios';
-import { OrgMember } from '../components/orgs/staff/members/org-member';
-import { Org } from '../components/orgs/org';
-import { routerHistory } from './history';
-import { useAuth } from './AuthProvider';
-import { FullPageCentered } from '../commons/components/FullPageCentered';
-import { Loader } from '../commons/components/Loader';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { toast } from "react-toastify";
+import { axios } from "./axios";
+import { OrgMember } from "../components/orgs/staff/members/org-member";
+import { Org } from "../components/orgs/org";
+import { routerHistory } from "./history";
+import { useAuth } from "./AuthProvider";
+import { FullPageCentered } from "../commons/components/FullPageCentered";
+import { Loader } from "../commons/components/Loader";
+import { extractErrorMessage } from "../utils/extract-error-message";
 
 export interface CurrentOrg {
   org: Org;
@@ -29,27 +36,28 @@ export const Context = createContext<OrgContext>(undefined);
 
 export const useCurrentOrg = () => useContext(Context);
 
-const storageKey = 'org';
+const storageKey = "org";
 
 export function OrgProvider(props) {
-  const [initialized, setInitialized] = useState(!localStorage.getItem(storageKey));
+  const [initialized, setInitialized] = useState(
+    !localStorage.getItem(storageKey)
+  );
   const [loading, setLoading] = useState(!!localStorage.getItem(storageKey));
   const [currentOrg, setCurrentOrg] = useState<CurrentOrg>();
   const { user } = useAuth();
 
   const signOutOrg = () => {
     setCurrentOrg(null);
-    localStorage.setItem(storageKey, '');
-    routerHistory.push('/orgs');
+    localStorage.setItem(storageKey, "");
+    routerHistory.push("/orgs");
   };
 
   const changeCurrentOrg = useCallback((orgId: string) => {
     setLoading(true);
-    return Promise
-      .all([
-        axios.get<Org>(`/api/v1/orgs/${orgId}`),
-        axios.get<OrgMember>(`/api/v1/orgs/${orgId}/member`),
-      ])
+    return Promise.all([
+      axios.get<Org>(`/api/v1/orgs/${orgId}`),
+      axios.get<OrgMember>(`/api/v1/orgs/${orgId}/member`),
+    ])
       .then(([{ data: org }, { data: member }]) => {
         const newCurrentOrg: CurrentOrg = {
           org,
@@ -70,11 +78,10 @@ export function OrgProvider(props) {
   useEffect(() => {
     const orgId = localStorage.getItem(storageKey);
     if (user && orgId) {
-      changeCurrentOrg(orgId)
-        .catch(err => {
-          toast.error(`Could not get current org: ${err}`);
-          signOutOrg();
-        });
+      changeCurrentOrg(orgId).catch((err) => {
+        toast.error(`Could not get current org: ${extractErrorMessage(err)}`);
+        signOutOrg();
+      });
     } else {
       setInitialized(true);
       setLoading(false);
@@ -94,13 +101,10 @@ export function OrgProvider(props) {
     <FullPageCentered>
       <p>
         Loading organization
-        <Loader className="ml-2"/>
+        <Loader className="ml-2" />
       </p>
     </FullPageCentered>
   ) : (
-    <Context.Provider
-      value={contextValue}
-      {...props}
-    />
+    <Context.Provider value={contextValue} {...props} />
   );
 }

--- a/ui/src/utils/extract-error-message.ts
+++ b/ui/src/utils/extract-error-message.ts
@@ -1,0 +1,9 @@
+import { AxiosError } from 'axios';
+
+export function extractErrorMessage(err: any) {
+  let message: string;
+  if (err.isAxiosError) {
+    message = (err as AxiosError).response?.data?.message;
+  }
+  return message || err.message;
+}

--- a/ui/src/utils/extract-exrror-message.ts
+++ b/ui/src/utils/extract-exrror-message.ts
@@ -1,8 +1,0 @@
-import { AxiosError } from 'axios';
-
-export function extractExrrorMessage(err: any) {
-  if (err.isAxiosError) {
-    return (err as AxiosError).response.data.message;
-  }
-  return err.message;
-}


### PR DESCRIPTION
This just modified the error handling on several `axios` calls
to extract the underlying error embedded in the HTTP response
so it is visible to the user.

Sorry for all the changes.  The only real changes here are to the 
`toast` calls.  It appears that this project doesn't include
a `.prettierrc` file to standardize `prettier` settings.  As s result, you'll
end up with this situation where all the files get formatted according
to different settings.  You might want to consider adding a `.prettierrc`
file to ensure consistent formatting (at least among VS Code users).

This closes #244