### PR TITLE
feat(ui): Improve toast error messages (retry)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/ui/src/components/auth/Orgs.tsx
+++ b/ui/src/components/auth/Orgs.tsx
@@ -10,6 +10,7 @@ import { useCurrentOrg } from '../../providers/OrgProvider';
 import { UserOrg } from './user-org';
 import { AddOrg } from '../orgs/AddOrg';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function OrgItem({ item }: {
   item: UserOrg;
@@ -21,7 +22,7 @@ function OrgItem({ item }: {
     setLoading(true);
     changeCurrentOrg(item.org._id)
       .catch(err => {
-        toast.error(`Could not select org: ${err}`);
+        toast.error(`Could not select org: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(true);

--- a/ui/src/components/auth/methods/SignInWithUserPassword.tsx
+++ b/ui/src/components/auth/methods/SignInWithUserPassword.tsx
@@ -8,6 +8,7 @@ import { useMountedState } from '../../../commons/hooks/use-mounted-state';
 import { axios } from '../../../providers/axios';
 import { useAuth } from '../../../providers/AuthProvider';
 import { Button } from '../../../commons/components/Button';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface FormData {
   user: string;
@@ -26,7 +27,7 @@ function useSignIn() {
         fetchUser();
       })
       .catch(err => {
-        toast.error(`Could not sign in: ${err}`);
+        toast.error(`Could not sign in: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/commons/Logo.tsx
+++ b/ui/src/components/commons/Logo.tsx
@@ -9,6 +9,7 @@ import { ButtonIcon } from '../../commons/components/ButtonIcon';
 import { Bubble } from '../../commons/components/Bubble';
 import { axios } from '../../providers/axios';
 import styles from './Logo.module.scss';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 interface Value {
   _id: string;
@@ -39,7 +40,7 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
         setValue(data);
       })
       .catch(err => {
-        toast.error(`Could not upload logo: ${err}`);
+        toast.error(`Could not upload logo: ${extractErrorMessage(err)}`);
       })
       .finally(() => setUploading(false));
   };
@@ -54,7 +55,7 @@ export function Logo<T extends Value>({ context, value, setValue, className }: {
         setValue(data);
       })
       .catch(err => {
-        toast.error(`Could not remove logo: ${err}`);
+        toast.error(`Could not remove logo: ${extractErrorMessage(err)}`);
       })
       .finally(() => setRemoving(false));
   };

--- a/ui/src/components/hooks/AddHook.tsx
+++ b/ui/src/components/hooks/AddHook.tsx
@@ -7,6 +7,7 @@ import { axios } from '../../providers/axios';
 import { HookForm } from './form/HookForm';
 import { useHookContext } from './HookProvider';
 import { routeUp } from '../../commons/utils/route-up';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function AddHook() {
   const { context } = useHookContext();
@@ -18,7 +19,7 @@ export function AddHook() {
         routerHistory.push(routeUp(url));
       })
       .catch(err => {
-        toast.error(`Could not create hook: ${err}`);
+        toast.error(`Could not create hook: ${extractErrorMessage(err)}`);
       }),
     [context, url],
   );

--- a/ui/src/components/hooks/DeleteHook.tsx
+++ b/ui/src/components/hooks/DeleteHook.tsx
@@ -5,6 +5,7 @@ import { axios } from '../../providers/axios';
 import { CardModal } from '../../commons/components/modals/CardModal';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { useHookContext } from './HookProvider';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function DeleteHook({
   hookId, className, children, onDelete,
@@ -27,7 +28,7 @@ export function DeleteHook({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete hook: ${err}`);
+        toast.error(`Could not delete hook: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/hooks/HookList.tsx
+++ b/ui/src/components/hooks/HookList.tsx
@@ -11,6 +11,7 @@ import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { useHookContext } from './HookProvider';
 import { Hook } from './hook';
 import { HookIcon } from '../icons/HookIcon';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function sortHooks(a: Hook, b: Hook): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -31,7 +32,7 @@ export function HookList() {
       .then(({ data }) => data.sort(sortHooks))
       .then(setHooks)
       .catch(setError)
-      .catch(err => toast.error(`Could not list hooks: ${err}`))
+      .catch(err => toast.error(`Could not list hooks: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [setLoading, context]);
 

--- a/ui/src/components/hooks/HookView.tsx
+++ b/ui/src/components/hooks/HookView.tsx
@@ -21,6 +21,7 @@ import { routeUp } from '../../commons/utils/route-up';
 import { NavPills } from '../../commons/components/NavPills';
 import { HookDeliveries } from './deliveries/HookDeliveries';
 import { NotFound } from '../../commons/components/NotFound';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function HookView() {
   const { hookId } = useParams<any>();
@@ -39,7 +40,7 @@ export function HookView() {
       .get<Hook>(`/api/v1/${context}/hooks/${hookId}`)
       .then(({ data }) => setHook(data))
       .catch(setError)
-      .catch(err => toast.error(`Could not get hook: ${err}`))
+      .catch(err => toast.error(`Could not get hook: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [setLoading, hookId, context]);
 

--- a/ui/src/components/hooks/TestHook.tsx
+++ b/ui/src/components/hooks/TestHook.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { Button } from '../../commons/components/Button';
 import { axios } from '../../providers/axios';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function TestHook({
   config, className, disabled,
@@ -18,7 +19,7 @@ export function TestHook({
     axios
       .post(`/api/v1/sites/notifications/test`, config)
       .then(() => toast.success('It worked !'))
-      .catch(err => toast.error(`It didnt work: ${err}`))
+      .catch(err => toast.error(`It didnt work: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
   return (

--- a/ui/src/components/hooks/deliveries/HookDeliveries.tsx
+++ b/ui/src/components/hooks/deliveries/HookDeliveries.tsx
@@ -12,6 +12,7 @@ import { Loader } from '../../../commons/components/Loader';
 import { AlertError } from '../../../commons/components/AlertError';
 import { EmptyList } from '../../../commons/components/EmptyList';
 import { HookDeliveryIcon } from '../../icons/HookDeliveryIcon';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function HookDeliveries() {
   const { context } = useHookContext();
@@ -38,7 +39,7 @@ export function HookDeliveries() {
         setHasMore(data.count > itemsRef.current.length);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list hook deliveries: ${err}`))
+      .catch(err => toast.error(`Could not list hook deliveries: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [pagination, hookId, setLoading, context]);
 

--- a/ui/src/components/hooks/form/HookEvents.tsx
+++ b/ui/src/components/hooks/form/HookEvents.tsx
@@ -7,6 +7,7 @@ import { axios } from '../../../providers/axios';
 import { Loader } from '../../../commons/components/Loader';
 import { AlertError } from '../../../commons/components/AlertError';
 import { Toggle } from '../../../commons/components/forms/Toggle';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function HookEvents() {
   const { context } = useHookContext();
@@ -23,7 +24,7 @@ export function HookEvents() {
       .then(({ data }) => data)
       .then(setEvents)
       .catch(setError)
-      .catch(err => toast.error(`Could not list hook events: ${err}`))
+      .catch(err => toast.error(`Could not list hook events: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [setLoading, context]);
 

--- a/ui/src/components/invites/AcceptInvite.tsx
+++ b/ui/src/components/invites/AcceptInvite.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../commons/components/Button';
 import { axios } from '../../providers/axios';
 import { UserOrg } from '../auth/user-org';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function AcceptInvite({
   inviteId, className, onAccept, token, disabled,
@@ -26,7 +27,7 @@ export function AcceptInvite({
       .then(({ data }) => data)
       .then(onAccept)
       .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/invites/DeclineInvite.tsx
+++ b/ui/src/components/invites/DeclineInvite.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../commons/components/Button';
 import { axios } from '../../providers/axios';
 import { UserOrg } from '../auth/user-org';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function DeclineInvite({
   inviteId, className, onIgnore, token, disabled,
@@ -25,7 +26,7 @@ export function DeclineInvite({
       })
       .then(() => onIgnore())
       .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/AddOrg.tsx
+++ b/ui/src/components/orgs/AddOrg.tsx
@@ -9,6 +9,7 @@ import { Button } from '../../commons/components/Button';
 import { CardModal } from '../../commons/components/modals/CardModal';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { UserOrg } from '../auth/user-org';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 interface Form {
   name: string;
@@ -35,7 +36,7 @@ function Modal({ closeModal, onAdded }: {
         closeModal();
       })
       .catch(err => {
-        toast.error(`Could not create org: ${err}`);
+        toast.error(`Could not create org: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/settings/OrgGeneralSettings.tsx
+++ b/ui/src/components/orgs/settings/OrgGeneralSettings.tsx
@@ -10,6 +10,7 @@ import { COLOR_PATTERN, required } from '../../../commons/components/forms/form-
 import { useOrg } from '../OrgView';
 import { Org } from '../org';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface Settings {
   name: string;
@@ -41,7 +42,7 @@ export function OrgGeneralSettings() {
       .then(({ data }) => data)
       .then(setOrg)
       .then(() => toast.success('Org saved'))
-      .catch(err => toast.error(`Could not update org: ${err}`))
+      .catch(err => toast.error(`Could not update org: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
 

--- a/ui/src/components/orgs/staff/invites/AddInvite.tsx
+++ b/ui/src/components/orgs/staff/invites/AddInvite.tsx
@@ -11,6 +11,7 @@ import { OrgMember } from '../members/org-member';
 import { useCurrentOrg } from '../../../../providers/OrgProvider';
 import { Toggle } from '../../../../commons/components/forms/Toggle';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 interface InviteRequest {
   email: string;
@@ -36,7 +37,7 @@ function AddMemberModal({ closeModal, onAdded }: {
     })
     .then(closeModal)
     .catch(err => {
-      toast.error(`Could not add invite: ${err}`);
+      toast.error(`Could not add invite: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/orgs/staff/invites/DeleteInvite.tsx
+++ b/ui/src/components/orgs/staff/invites/DeleteInvite.tsx
@@ -5,6 +5,7 @@ import { axios } from '../../../../providers/axios';
 import { CardModal } from '../../../../commons/components/modals/CardModal';
 import { useCurrentOrg } from '../../../../providers/OrgProvider';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function DeleteInvite({
   inviteId, className, children, onDelete,
@@ -27,7 +28,7 @@ export function DeleteInvite({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/staff/invites/Invites.tsx
+++ b/ui/src/components/orgs/staff/invites/Invites.tsx
@@ -12,6 +12,7 @@ import { AddInvite } from './AddInvite';
 import { useCurrentOrg } from '../../../../providers/OrgProvider';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
 import { ButtonIcon } from '../../../../commons/components/ButtonIcon';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 function sortInvites(a: Invite, b: Invite): number {
   return new Date(b.expiresAt).getTime() - new Date(a.expiresAt).getTime();
@@ -30,7 +31,7 @@ export function Invites() {
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list invites: ${err}`))
+      .catch(err => toast.error(`Could not list invites: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [currentOrg, setLoading]);
 

--- a/ui/src/components/orgs/staff/members/DeleteMember.tsx
+++ b/ui/src/components/orgs/staff/members/DeleteMember.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../../commons/components/Button';
 import { axios } from '../../../../providers/axios';
 import { CardModal } from '../../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function DeleteMember({
   memberId, className, children, onDelete,
@@ -25,7 +26,7 @@ export function DeleteMember({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete member: ${err}`);
+        toast.error(`Could not delete member: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/staff/members/MemberView.tsx
+++ b/ui/src/components/orgs/staff/members/MemberView.tsx
@@ -15,6 +15,7 @@ import { Loader } from '../../../../commons/components/Loader';
 import { DropdownLink } from '../../../../commons/components/dropdown/DropdownLink';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
 import { IsOwner } from '../../../auth/IsOwner';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 function AdminToggle({ member, setMember }: {
   member: OrgMember;
@@ -31,7 +32,7 @@ function AdminToggle({ member, setMember }: {
       .then(({ data }) => data)
       .then(setMember)
       .catch(err => {
-        toast.error(`Could not toggle admin: ${err}`);
+        toast.error(`Could not toggle admin: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/orgs/staff/members/Members.tsx
+++ b/ui/src/components/orgs/staff/members/Members.tsx
@@ -10,6 +10,7 @@ import { MemberView } from './MemberView';
 import { OrgMember } from './org-member';
 import { OrgMemberIcon } from '../../../icons/OrgMemberIcon';
 import { Loader } from '../../../../commons/components/Loader';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function Members() {
   const [loading, setLoading] = useMountedState(true);
@@ -75,7 +76,7 @@ export function Members() {
         setCanLoadMore(itemsRef.current.length !== data.count);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list members: ${err}`))
+      .catch(err => toast.error(`Could not list members: ${extractErrorMessage(err)}`))
       .finally(() => {
         setSearching(false);
         setLoading(false);

--- a/ui/src/components/projects/AddProject.tsx
+++ b/ui/src/components/projects/AddProject.tsx
@@ -16,6 +16,7 @@ import { Project } from './project';
 import { useCurrentOrg } from '../../providers/OrgProvider';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { IsAdmin } from '../auth/IsAdmin';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function AddProjectModal({ closeModal, onAdded }: {
   closeModal;
@@ -40,7 +41,7 @@ function AddProjectModal({ closeModal, onAdded }: {
       closeModal();
     })
     .catch(err => {
-      toast.error(`Could not create project: ${err}`);
+      toast.error(`Could not create project: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/projects/DeleteProject.tsx
+++ b/ui/src/components/projects/DeleteProject.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../commons/components/Button';
 import { CardModal } from '../../commons/components/modals/CardModal';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { IsAdmin } from '../auth/IsAdmin';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function DeleteProject({
   id, className, children,
@@ -26,7 +27,7 @@ export function DeleteProject({
         routerHistory.push('/');
       })
       .catch(err => {
-        toast.error(`Could not delete project: ${err}`);
+        toast.error(`Could not delete project: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/projects/ProjectList.tsx
+++ b/ui/src/components/projects/ProjectList.tsx
@@ -18,6 +18,7 @@ import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { useRoom } from '../../websockets/use-room';
 import { EventType } from '../../websockets/event-type';
 import { Org } from '../orgs/org';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function ProjectList() {
   const { currentOrg } = useCurrentOrg();
@@ -43,7 +44,7 @@ export function ProjectList() {
         setItems(itemsRef.current);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list repositories: ${err}`))
+      .catch(err => toast.error(`Could not list repositories: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [pagination, currentOrg, setLoading]);
 

--- a/ui/src/components/projects/members/DeleteMember.tsx
+++ b/ui/src/components/projects/members/DeleteMember.tsx
@@ -5,6 +5,7 @@ import { axios } from '../../../providers/axios';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
 import { IsAdmin } from '../../auth/IsAdmin';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function DeleteMember({
   projectId, memberId, className, children, onDelete,
@@ -27,7 +28,7 @@ export function DeleteMember({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete member: ${err}`);
+        toast.error(`Could not delete member: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/projects/members/Members.tsx
+++ b/ui/src/components/projects/members/Members.tsx
@@ -12,6 +12,7 @@ import { MemberView } from './MemberView';
 import styles from './Members.module.scss';
 import { ProjectMemberIcon } from '../../icons/ProjectMemberIcon';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function sortMembers(a: ProjectMember, b: ProjectMember): number {
   return a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
@@ -30,7 +31,7 @@ export function Members() {
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list members: ${err}`))
+      .catch(err => toast.error(`Could not list members: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [projectId, setLoading]);
 

--- a/ui/src/components/projects/members/add/AddMember.tsx
+++ b/ui/src/components/projects/members/add/AddMember.tsx
@@ -13,6 +13,7 @@ import { useCurrentOrg } from '../../../../providers/OrgProvider';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
 import { IsAdmin } from '../../../auth/IsAdmin';
 import { ProjectMember } from '../project-member';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function AddMember({
   projectId, className, children, onAdded,
@@ -45,7 +46,7 @@ export function AddMember({
       })
       .catch(setError)
       .catch(err => {
-        toast.error(`Could not search releases: ${err}`);
+        toast.error(`Could not search releases: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);

--- a/ui/src/components/projects/members/add/ListItem.tsx
+++ b/ui/src/components/projects/members/add/ListItem.tsx
@@ -6,6 +6,7 @@ import { Loader } from '../../../../commons/components/Loader';
 import { OrgMember } from '../../../orgs/staff/members/org-member';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
 import { ProjectMember } from '../project-member';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function ListItem({
   projectId, member, onAdded,
@@ -26,7 +27,7 @@ export function ListItem({
         onAdded(data);
       })
       .catch(err => {
-        toast.error(`Could not select branch: ${err}`);
+        toast.error(`Could not select branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/projects/settings/ProjectGeneralSettings.tsx
+++ b/ui/src/components/projects/settings/ProjectGeneralSettings.tsx
@@ -10,6 +10,7 @@ import { axios } from '../../../providers/axios';
 import { InputError } from '../../../commons/components/forms/InputError';
 import { COLOR_PATTERN, required } from '../../../commons/components/forms/form-constants';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface Settings {
   name: string;
@@ -42,7 +43,7 @@ export function ProjectGeneralSettings() {
       .then(({ data }) => data)
       .then(setProject)
       .then(() => toast.success('Project saved'))
-      .catch(err => toast.error(`Could not update project: ${err}`))
+      .catch(err => toast.error(`Could not update project: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
 

--- a/ui/src/components/sidebar/Projects.tsx
+++ b/ui/src/components/sidebar/Projects.tsx
@@ -16,6 +16,7 @@ import { useCurrentOrg } from '../../providers/OrgProvider';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { useRoom } from '../../websockets/use-room';
 import { EventType } from '../../websockets/event-type';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function sortProjects(a: Project, b: Project) {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -75,7 +76,7 @@ export function Projects({ className }: { className? }) {
         setProjects(projectsRef.current.sort(sortProjects));
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list projects: ${err}`))
+      .catch(err => toast.error(`Could not list projects: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [currentOrg, setLoading]);
 

--- a/ui/src/components/sidebar/Sites.tsx
+++ b/ui/src/components/sidebar/Sites.tsx
@@ -11,6 +11,7 @@ import { Bubble } from '../../commons/components/Bubble';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { EventType } from '../../websockets/event-type';
 import { useRoom } from '../../websockets/use-room';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function sortSites(a: Site, b: Site) {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -58,7 +59,7 @@ export function Sites({ projectId, className }: { projectId; className? }) {
         setItems(items.sort(sortSites));
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list sites: ${err}`))
+      .catch(err => toast.error(`Could not list sites: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [projectId, setLoading]);
 

--- a/ui/src/components/sites/AddSite.tsx
+++ b/ui/src/components/sites/AddSite.tsx
@@ -11,6 +11,7 @@ import { CardModal } from '../../commons/components/modals/CardModal';
 import { Site } from './site';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { IsAdmin } from '../auth/IsAdmin';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function AddSiteModal({ projectId, closeModal }: { projectId; closeModal }) {
   const methods = useForm({
@@ -28,7 +29,7 @@ function AddSiteModal({ projectId, closeModal }: { projectId; closeModal }) {
       closeModal();
     })
     .catch(err => {
-      toast.error(`Could not create site: ${err}`);
+      toast.error(`Could not create site: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/sites/DeleteSite.tsx
+++ b/ui/src/components/sites/DeleteSite.tsx
@@ -5,6 +5,7 @@ import { routerHistory } from '../../providers/history';
 import { Button } from '../../commons/components/Button';
 import { CardModal } from '../../commons/components/modals/CardModal';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function DeleteSite({
   id, projectId, className, children,
@@ -26,7 +27,7 @@ export function DeleteSite({
         routerHistory.push(`/projects/${projectId}/sites`);
       })
       .catch(err => {
-        toast.error(`Could not delete site: ${err}`);
+        toast.error(`Could not delete site: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/SiteList.tsx
+++ b/ui/src/components/sites/SiteList.tsx
@@ -11,6 +11,7 @@ import { Site } from './site';
 import { AddSite } from './AddSite';
 import { SiteIcon } from '../icons/SiteIcon';
 import { useMountedState } from '../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 export function SiteList() {
   const { projectId } = useParams<any>();
@@ -28,7 +29,7 @@ export function SiteList() {
         setItems(itemsRef.current);
       })
       .catch(setError)
-      .catch(err => toast.error(`Could not list repos: ${err}`))
+      .catch(err => toast.error(`Could not list repos: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [projectId, setLoading]);
 

--- a/ui/src/components/sites/branches/AddBranch.tsx
+++ b/ui/src/components/sites/branches/AddBranch.tsx
@@ -7,6 +7,7 @@ import { CardModal } from '../../../commons/components/modals/CardModal';
 import { Branch } from './branch';
 import { BranchNameInput } from './BranchNameInput';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function ModalContent({
   siteId, releaseId, onAdded,
@@ -29,7 +30,7 @@ function ModalContent({
     .then(({ data }) => data)
     .then(onAdded)
     .catch(err => {
-      toast.error(`Could not create branch: ${err}`);
+      toast.error(`Could not create branch: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/sites/branches/BranchList.tsx
+++ b/ui/src/components/sites/branches/BranchList.tsx
@@ -12,6 +12,7 @@ import { AddBranch } from './AddBranch';
 import { Branch } from './branch';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
 import { BranchListItemView } from './BranchListItem';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function sortBranches(a: Branch, b: Branch): number {
   return new Date(b.name).getTime() - new Date(a.name).getTime();
@@ -29,7 +30,7 @@ export function BranchList() {
     axios.get<Branch[]>(`/api/v1/sites/${siteId}/branches`)
       .then(({ data }) => setItems(data))
       .catch(setError)
-      .catch(err => toast.error(`Could not list branches: ${err}`))
+      .catch(err => toast.error(`Could not list branches: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [siteId, setLoading]);
 

--- a/ui/src/components/sites/branches/BranchNameInput.tsx
+++ b/ui/src/components/sites/branches/BranchNameInput.tsx
@@ -6,6 +6,7 @@ import { debounceTime } from '../../../utils/debounce-time';
 import { InputError } from '../../../commons/components/forms/InputError';
 import { axios } from '../../../providers/axios';
 import { useSite } from '../SiteView';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 async function validateName(siteId: string, name: string): Promise<string | undefined> {
   if (!name) {
@@ -17,7 +18,7 @@ async function validateName(siteId: string, name: string): Promise<string | unde
     })
     .then(({ data }) => data || undefined)
     .catch(err => {
-      toast.error(`Could not validate branch name: ${err}`);
+      toast.error(`Could not validate branch name: ${extractErrorMessage(err)}`);
       return undefined;
     });
 }

--- a/ui/src/components/sites/branches/BranchPassword.tsx
+++ b/ui/src/components/sites/branches/BranchPassword.tsx
@@ -10,6 +10,7 @@ import { InputError } from '../../../commons/components/forms/InputError';
 import { maxLength, required } from '../../../commons/components/forms/form-constants';
 import { axios } from '../../../providers/axios';
 import { randomString } from '../../../commons/utils/random-string';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface FormData {
   password: string;
@@ -50,7 +51,7 @@ export function BranchPassword({
         closeModal();
       })
       .catch(err => {
-        toast.error(`Could not set branch password: ${err}`);
+        toast.error(`Could not set branch password: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -61,7 +62,7 @@ export function BranchPassword({
       .delete<Branch>(`/api/v1/sites/${siteId}/branches/${branch._id}/password`)
       .then(({ data }) => onChange(data))
       .catch(err => {
-        toast.error(`Could not remove branch password: ${err}`);
+        toast.error(`Could not remove branch password: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/DeleteBranch.tsx
+++ b/ui/src/components/sites/branches/DeleteBranch.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../commons/components/Button';
 import { axios } from '../../../providers/axios';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function DeleteBranch({
   siteId, branchId, className, children, onDelete,
@@ -26,7 +27,7 @@ export function DeleteBranch({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete branch: ${err}`);
+        toast.error(`Could not delete branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/RenameBranch.tsx
+++ b/ui/src/components/sites/branches/RenameBranch.tsx
@@ -7,6 +7,7 @@ import { CardModal } from '../../../commons/components/modals/CardModal';
 import { Branch } from './branch';
 import { BranchNameInput } from './BranchNameInput';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function ModalContent({
   siteId, branchId, onRenamed,
@@ -27,7 +28,7 @@ function ModalContent({
       .put<Branch>(`/api/v1/sites/${siteId}/branches/${branchId}/name`, formData)
       .then(({ data }) => onRenamed(data))
       .catch(err => {
-        toast.error(`Could not rename branch: ${err}`);
+        toast.error(`Could not rename branch: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/forms/Forms.tsx
+++ b/ui/src/components/sites/branches/forms/Forms.tsx
@@ -8,6 +8,7 @@ import { AlertError } from '../../../../commons/components/AlertError';
 import { Branch } from '../branch';
 import { FormList } from './FormList';
 import { Form, Release } from '../../releases/release';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 function useBranchForms(
   siteId: string,
@@ -60,7 +61,7 @@ function useSetBranchForms(
         toast.success('Saved forms');
       })
       .catch(err => {
-        toast.error(`Could not save forms: ${err}`);
+        toast.error(`Could not save forms: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);

--- a/ui/src/components/sites/branches/headers/BranchHeaders.tsx
+++ b/ui/src/components/sites/branches/headers/BranchHeaders.tsx
@@ -11,6 +11,7 @@ import { Branch } from '../branch';
 import { Header } from '../header';
 import { HeaderList } from '../../headers/HeaderList';
 import { useSiteHeaders } from '../../headers/use-site-headers';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 function useBranchHeaders(
   siteId: string,
@@ -57,7 +58,7 @@ function useSetBranchHeaders(
         toast.success('Saved branch headers');
       })
       .catch(err => {
-        toast.error(`Could not save headers: ${err}`);
+        toast.error(`Could not save headers: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);

--- a/ui/src/components/sites/branches/redirects/BranchRedirects.tsx
+++ b/ui/src/components/sites/branches/redirects/BranchRedirects.tsx
@@ -10,6 +10,7 @@ import { Button } from '../../../../commons/components/Button';
 import { BranchRedirectsFormData } from './branch-redirects-form-data';
 import { BranchRedirectForm } from './BranchRedirectForm';
 import { BranchRedirect, RedirectType } from '../branch-redirect';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 function useBranchFiles(
   siteId: string,
@@ -56,7 +57,7 @@ function useSetFiles(
         toast.success('Saved branch redirects');
       })
       .catch(err => {
-        toast.error(`Could not save branch redirects: ${err}`);
+        toast.error(`Could not save branch redirects: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/release/SetBranchRelease.tsx
+++ b/ui/src/components/sites/branches/release/SetBranchRelease.tsx
@@ -5,6 +5,7 @@ import { axios } from '../../../../providers/axios';
 import { CardModal } from '../../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
 import { Branch } from '../branch';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 export function SetBranchRelease({
   siteId, branchId, releaseId, className, children, onSet, branchName, releaseName,
@@ -32,7 +33,7 @@ export function SetBranchRelease({
         onSet();
       })
       .catch(err => {
-        toast.error(`Could not set branch release: ${err}`);
+        toast.error(`Could not set branch release: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/branches/settings/BranchGeneralSettings.tsx
+++ b/ui/src/components/sites/branches/settings/BranchGeneralSettings.tsx
@@ -6,6 +6,7 @@ import { Site, SiteDomain } from '../../site';
 import { useSite } from '../../SiteView';
 import { axios } from '../../../../providers/axios';
 import { useMountedState } from '../../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../../utils/extract-error-message';
 
 interface Settings {
   name: string;
@@ -37,7 +38,7 @@ export function BranchGeneralSettings() {
       .then(({ data }) => data)
       .then(setSite)
       .then(() => toast.success('Site saved'))
-      .catch(err => toast.error(`Could not update site: ${err}`))
+      .catch(err => toast.error(`Could not update site: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
 

--- a/ui/src/components/sites/headers/SiteHeaders.tsx
+++ b/ui/src/components/sites/headers/SiteHeaders.tsx
@@ -9,6 +9,7 @@ import { Loader } from '../../../commons/components/Loader';
 import { AlertError } from '../../../commons/components/AlertError';
 import { axios } from '../../../providers/axios';
 import { useSiteHeaders } from './use-site-headers';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function useSetSiteHeaders(
   siteId: string,
@@ -27,7 +28,7 @@ function useSetSiteHeaders(
         toast.success('Saved branch headers');
       })
       .catch(err => {
-        toast.error(`Could not save headers: ${err}`);
+        toast.error(`Could not save headers: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);

--- a/ui/src/components/sites/releases/DeleteRelease.tsx
+++ b/ui/src/components/sites/releases/DeleteRelease.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../commons/components/Button';
 import { axios } from '../../../providers/axios';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function DeleteRelease({
   releaseId, className, children, onDelete,
@@ -25,7 +26,7 @@ export function DeleteRelease({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete release: ${err}`);
+        toast.error(`Could not delete release: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/releases/Releases.tsx
+++ b/ui/src/components/sites/releases/Releases.tsx
@@ -17,6 +17,7 @@ import { useRoom } from '../../../websockets/use-room';
 import { EventType } from '../../../websockets/event-type';
 import { Site } from '../site';
 import { useEnv } from '../../../providers/EnvProvider';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function UploadReleaseSnippet({ siteId, className }: { siteId: string; className? }) {
   const env = useEnv();
@@ -127,7 +128,7 @@ export function Releases() {
       })
       .catch(setError)
       .catch(err => {
-        toast.error(`Could not list releases: ${err}`);
+        toast.error(`Could not list releases: ${extractErrorMessage(err)}`);
       })
       .finally(() => {
         setLoading(false);

--- a/ui/src/components/sites/releases/RenameRelease.tsx
+++ b/ui/src/components/sites/releases/RenameRelease.tsx
@@ -7,6 +7,7 @@ import { CardModal } from '../../../commons/components/modals/CardModal';
 import { Release } from './release';
 import { ReleaseNameInput } from './ReleaseNameInput';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function ModalContent({ releaseId, onRenamed }: {
   releaseId: string;
@@ -23,7 +24,7 @@ function ModalContent({ releaseId, onRenamed }: {
     .then(({ data }) => data)
     .then(onRenamed)
     .catch(err => {
-      toast.error(`Could not rename release: ${err}`);
+      toast.error(`Could not rename release: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/sites/search/SearchModal.tsx
+++ b/ui/src/components/sites/search/SearchModal.tsx
@@ -9,6 +9,7 @@ import { Loader } from '../../../commons/components/Loader';
 import { SiteCard } from '../SiteCard';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useSites } from '../use-sites';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModal: () => void }) {
   const search$ = useRef(new BehaviorSubject(''));
@@ -37,7 +38,7 @@ export function SearchModal({ isOpen, closeModal }: { isOpen: boolean; closeModa
 
   useEffect(() => {
     if (error) {
-      toast.error(`Could not search sites: ${error}`);
+      toast.error(`Could not search sites: ${extractErrorMessage(error)}`);
     }
   }, [error]);
 

--- a/ui/src/components/sites/settings/GeneralSettingsForm.tsx
+++ b/ui/src/components/sites/settings/GeneralSettingsForm.tsx
@@ -17,6 +17,7 @@ import { Toggle } from '../../../commons/components/forms/Toggle';
 import { DocsLink } from '../../../commons/components/DocsLink';
 import { DomainForm } from './DomainForm';
 import { Button } from '../../../commons/components/Button';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface Settings {
   name: string;
@@ -54,7 +55,7 @@ export function GeneralSettingsForm() {
       .then(({ data }) => data)
       .then(setSite)
       .then(() => toast.success('Site saved'))
-      .catch(err => toast.error(`Could not update site: ${err}`))
+      .catch(err => toast.error(`Could not update site: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   };
 

--- a/ui/src/components/sites/settings/SiteNameInput.tsx
+++ b/ui/src/components/sites/settings/SiteNameInput.tsx
@@ -5,6 +5,7 @@ import { isSubdomain, maxLength, required } from '../../../commons/components/fo
 import { debounceTime } from '../../../utils/debounce-time';
 import { InputError } from '../../../commons/components/forms/InputError';
 import { axios } from '../../../providers/axios';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 async function validateName(name: string, previousName?: string): Promise<string | undefined> {
   if (!name) {
@@ -19,7 +20,7 @@ async function validateName(name: string, previousName?: string): Promise<string
     })
     .then(({ data }) => data || undefined)
     .catch(err => {
-      toast.error(`Could not validate site name: ${err}`);
+      toast.error(`Could not validate site name: ${extractErrorMessage(err)}`);
       return undefined;
     });
 }

--- a/ui/src/components/sites/settings/SitePassword.tsx
+++ b/ui/src/components/sites/settings/SitePassword.tsx
@@ -10,6 +10,7 @@ import { maxLength, required } from '../../../commons/components/forms/form-cons
 import { axios } from '../../../providers/axios';
 import { randomString } from '../../../commons/utils/random-string';
 import { Site } from '../site';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 interface FormData {
   password: string;
@@ -49,7 +50,7 @@ export function SitePassword({
         closeModal();
       })
       .catch(err => {
-        toast.error(`Could not set site password: ${err}`);
+        toast.error(`Could not set site password: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };
@@ -60,7 +61,7 @@ export function SitePassword({
       .delete<Site>(`/api/v1/sites/${site._id}/password`)
       .then(({ data }) => onChange(data))
       .catch(err => {
-        toast.error(`Could not remove site password: ${err}`);
+        toast.error(`Could not remove site password: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/tokens/AddToken.tsx
+++ b/ui/src/components/sites/tokens/AddToken.tsx
@@ -9,6 +9,7 @@ import { maxLength, required } from '../../../commons/components/forms/form-cons
 import { InputError } from '../../../commons/components/forms/InputError';
 import styles from './AddToken.module.scss';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function AddTokenModal({
   closeModal, siteId, onAdded,
@@ -31,7 +32,7 @@ function AddTokenModal({
     })
     .then(closeModal)
     .catch(err => {
-      toast.error(`Could not create token: ${err}`);
+      toast.error(`Could not create token: ${extractErrorMessage(err)}`);
     });
 
   const onSubmit = data => {

--- a/ui/src/components/sites/tokens/DeleteToken.tsx
+++ b/ui/src/components/sites/tokens/DeleteToken.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../commons/components/Button';
 import { axios } from '../../../providers/axios';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function DeleteToken({
   siteId, tokenId, className, children, onDelete,
@@ -26,7 +27,7 @@ export function DeleteToken({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete token: ${err}`);
+        toast.error(`Could not delete token: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/sites/tokens/TokenList.tsx
+++ b/ui/src/components/sites/tokens/TokenList.tsx
@@ -12,6 +12,7 @@ import { TokenView } from './TokenView';
 import styles from './TokenList.module.scss';
 import { TokenIcon } from '../../icons/TokenIcon';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function sortTokens(a: Token, b: Token): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -30,7 +31,7 @@ export function TokenList() {
       .then(({ data }) => data)
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list tokens: ${err}`))
+      .catch(err => toast.error(`Could not list tokens: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [siteId, setLoading]);
 

--- a/ui/src/components/user/UserSecurity.tsx
+++ b/ui/src/components/user/UserSecurity.tsx
@@ -4,6 +4,7 @@ import { useMountedState } from '../../commons/hooks/use-mounted-state';
 import { axios } from '../../providers/axios';
 import { Button } from '../../commons/components/Button';
 import { useAuth } from '../../providers/AuthProvider';
+import { extractErrorMessage } from '../../utils/extract-error-message';
 
 function Disconnect() {
   const [loading, setLoading] = useMountedState(false);
@@ -17,7 +18,7 @@ function Disconnect() {
         signOut();
       })
       .catch(err => {
-        toast.error(`Could not delete invite: ${err}`);
+        toast.error(`Could not delete invite: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/components/user/api-tokens/AddApiToken.tsx
+++ b/ui/src/components/user/api-tokens/AddApiToken.tsx
@@ -4,6 +4,7 @@ import { axios } from '../../../providers/axios';
 import { ApiToken } from './api-token';
 import { ApiTokenForm, ApiTokenFormData } from './ApiTokenForm';
 import { routerHistory } from '../../../providers/history';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function AddApiToken() {
   const onChange = (data: ApiTokenFormData): Promise<void> => axios
@@ -17,7 +18,7 @@ export function AddApiToken() {
       routerHistory.push('/user/api-tokens');
     })
     .catch(err => {
-      toast.error(`Could not create api token: ${err}`);
+      toast.error(`Could not create api token: ${extractErrorMessage(err)}`);
     });
   return (
     <ApiTokenForm onChange={onChange}/>

--- a/ui/src/components/user/api-tokens/ApiTokenList.tsx
+++ b/ui/src/components/user/api-tokens/ApiTokenList.tsx
@@ -11,6 +11,7 @@ import styles from './ApiTokenList.module.scss';
 import { TokenIcon } from '../../icons/TokenIcon';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
 import { ApiTokenActivationPeriod } from './ApiTokenActivationPeriod';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 function sortTokens(a: ApiToken, b: ApiToken): number {
   return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -30,7 +31,7 @@ export function ApiTokenList() {
       .then(({ data }) => data.sort(sortTokens))
       .then(setItems)
       .catch(setError)
-      .catch(err => toast.error(`Could not list tokens: ${err}`))
+      .catch(err => toast.error(`Could not list tokens: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [setLoading]);
 

--- a/ui/src/components/user/api-tokens/ApiTokenView.tsx
+++ b/ui/src/components/user/api-tokens/ApiTokenView.tsx
@@ -20,6 +20,7 @@ import { routerHistory } from '../../../providers/history';
 import { ApiTokenActivationPeriod } from './ApiTokenActivationPeriod';
 import { CopyToClipboard } from '../../../commons/components/CopyToClipboard';
 import { routeUp } from '../../../commons/utils/route-up';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function ApiTokenView() {
   const { apiTokenId } = useParams<any>();
@@ -38,7 +39,7 @@ export function ApiTokenView() {
       .then(({ data }) => data)
       .then(setApiToken)
       .catch(setError)
-      .catch(err => toast.error(`Could not get api token: ${err}`))
+      .catch(err => toast.error(`Could not get api token: ${extractErrorMessage(err)}`))
       .finally(() => setLoading(false));
   }, [setLoading, apiTokenId]);
 
@@ -52,7 +53,7 @@ export function ApiTokenView() {
       })
       .then(({ data }) => setApiToken(data))
       .catch(err => {
-        toast.error(`Could not update api token: ${err}`);
+        toast.error(`Could not update api token: ${extractErrorMessage(err)}`);
       }),
     [apiTokenId],
   );

--- a/ui/src/components/user/api-tokens/DeleteApiToken.tsx
+++ b/ui/src/components/user/api-tokens/DeleteApiToken.tsx
@@ -4,6 +4,7 @@ import { Button } from '../../../commons/components/Button';
 import { axios } from '../../../providers/axios';
 import { CardModal } from '../../../commons/components/modals/CardModal';
 import { useMountedState } from '../../../commons/hooks/use-mounted-state';
+import { extractErrorMessage } from '../../../utils/extract-error-message';
 
 export function DeleteApiToken({
   tokenId, className, children, onDelete,
@@ -25,7 +26,7 @@ export function DeleteApiToken({
         onDelete();
       })
       .catch(err => {
-        toast.error(`Could not delete api token: ${err}`);
+        toast.error(`Could not delete api token: ${extractErrorMessage(err)}`);
       })
       .finally(() => setLoading(false));
   };

--- a/ui/src/providers/AuthProvider.tsx
+++ b/ui/src/providers/AuthProvider.tsx
@@ -3,6 +3,7 @@ import { toast } from 'react-toastify';
 import { axios } from './axios';
 import { Loader } from '../commons/components/Loader';
 import { FullPageCentered } from '../commons/components/FullPageCentered';
+import { extractErrorMessage } from '../utils/extract-error-message';
 
 export interface User {
   _id: string;
@@ -38,7 +39,7 @@ export function AuthProvider(props) {
         window.location.href = '/';
       })
       .catch(err => {
-        toast.error(`Could not sign out properly: ${err}`);
+        toast.error(`Could not sign out properly: ${extractErrorMessage(err)}`);
       });
   }, []);
 
@@ -48,7 +49,7 @@ export function AuthProvider(props) {
       .get(`/api/v1/user`)
       .then(({ data }) => setUser(data))
       .catch(err => {
-        toast.error(`Could not get user: ${err}`);
+        toast.error(`Could not get user: ${extractErrorMessage(err)}`);
         setUser(null);
       })
       .finally(() => {

--- a/ui/src/providers/OrgProvider.tsx
+++ b/ui/src/providers/OrgProvider.tsx
@@ -7,6 +7,7 @@ import { routerHistory } from './history';
 import { useAuth } from './AuthProvider';
 import { FullPageCentered } from '../commons/components/FullPageCentered';
 import { Loader } from '../commons/components/Loader';
+import { extractErrorMessage } from '../utils/extract-error-message';
 
 export interface CurrentOrg {
   org: Org;
@@ -72,7 +73,7 @@ export function OrgProvider(props) {
     if (user && orgId) {
       changeCurrentOrg(orgId)
         .catch(err => {
-          toast.error(`Could not get current org: ${err}`);
+          toast.error(`Could not get current org: ${extractErrorMessage(err)}`);
           signOutOrg();
         });
     } else {

--- a/ui/src/utils/extract-error-message.ts
+++ b/ui/src/utils/extract-error-message.ts
@@ -1,6 +1,6 @@
 import { AxiosError } from 'axios';
 
-export function extractExrrorMessage(err: any) {
+export function extractErrorMessage(err: any) {
   if (err.isAxiosError) {
     return (err as AxiosError).response.data.message;
   }


### PR DESCRIPTION
feat(ui): Improve toast error messages

This just modified the error handling on several axios calls
to extract the underlying error embedded in the HTTP response
so it is visible to the user. The function for doing this already
existed but was never used (and had a typo in the name which
I've also corrected here).
